### PR TITLE
Renamed Hightimedelta to TimeDelta and Highdatetime to DateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hightime
 
 Overview
 --------
-Hightime allows for virtually infinite sub-second precision by providing API-compatible replacements for datetime.datetime (hightime.Highdatetime) and datetime.timedelta (hightime.Hightimedelta).
+Hightime allows for virtually infinite sub-second precision by providing API-compatible replacements for datetime.datetime (hightime.DateTime) and datetime.timedelta (hightime.TimeDelta).
 
 Installation
 ------------
@@ -24,14 +24,14 @@ Examples
 --------
 
 ```python
->>> from hightime import Highdatetime, Hightimedelta, SITimeUnit
+>>> from hightime import DateTime, TimeDelta, SITimeUnit
 
->>> now = Highdatetime.now()
+>>> now = DateTime.now()
 
 >>> print(now)
 2018-05-06 19:53:14.170736
 
->>> increment = Hightimedelta(frac_seconds=135, frac_seconds_exponent=-13)
+>>> increment = TimeDelta(frac_seconds=135, frac_seconds_exponent=-13)
 
 >>> print(increment)
 0:00:00+135e-13
@@ -49,7 +49,7 @@ Examples
 >>> print(later + now)
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unsupported operand type(s) for +: 'Highdatetime' and 'Highdatetime'
+TypeError: unsupported operand type(s) for +: 'DateTime' and 'DateTime'
 
 >>> print(later - now)
 0:00:00+270e-13
@@ -62,7 +62,7 @@ TypeError: unsupported operand type(s) for +: 'Highdatetime' and 'Highdatetime'
 >>> print(later)
 2018-05-06 19:53:14+1707390000270e-13
 
->>> later += Hightimedelta(frac_seconds=2, frac_seconds_exponent=SITimeUnit.ATTOSECONDS)
+>>> later += TimeDelta(frac_seconds=2, frac_seconds_exponent=SITimeUnit.ATTOSECONDS)
 
 >>> print(later)
 2018-05-06 19:53:14+170739000027000002e-18

--- a/hightime/__init__.py
+++ b/hightime/__init__.py
@@ -127,12 +127,12 @@ Examples:
 
 >>> delta_t = Hightime( 22.23 ) - Hightime( 0.1 )
 >>> delta_t
-<hightimedelta.Hightimedelta object at 0x7f682e322cd0>
+<hightimedelta.TimeDelta object at 0x7f682e322cd0>
 >>> print delta_t
 22s 130ms
 
 """
 
-from .highdatetime import Highdatetime  # noqa: F401
-from .hightimedelta import Hightimedelta  # noqa: F401
+from .highdatetime import DateTime  # noqa: F401
+from .hightimedelta import TimeDelta  # noqa: F401
 from .sitimeunit import SITimeUnit  # noqa: F401

--- a/hightime/highdatetime.py
+++ b/hightime/highdatetime.py
@@ -3,11 +3,11 @@ from . import util
 from .sitimeunit import SITimeUnit
 
 
-class Highdatetime(object):
+class DateTime(object):
 
     __slots__ = '_datetime', '_frac_second', '_frac_second_exponent'
 
-    # Highdatetime resolution is virtually infinite, None represents infinity?
+    # DateTime resolution is virtually infinite, None represents infinity?
     resolution = None
     min = datetime.min
     max = datetime.max
@@ -176,7 +176,7 @@ class Highdatetime(object):
 
     def __eq__(self, other):
         # FIXME: is isinstance() the right way to check this?
-        if isinstance(other, Highdatetime) or isinstance(other, datetime):
+        if isinstance(other, DateTime) or isinstance(other, datetime):
             # check sub-second value first since that is more likely different.
             (frac_second,
              other_frac_second,
@@ -194,7 +194,7 @@ class Highdatetime(object):
         return False
 
     def __add__(self, other):
-        if isinstance(other, Hightimedelta) or isinstance(other, timedelta):
+        if isinstance(other, TimeDelta) or isinstance(other, timedelta):
             # add values without sub-seconds, then deal with normalized
             # sub-seconds separately.
             # FIXME: this results in 2 ctor calls, make more efficient
@@ -219,27 +219,27 @@ class Highdatetime(object):
                                       result_frac_second)
 
             # FIXME: fold?
-            return Highdatetime(year=result.year,
-                                month=result.month,
-                                day=result.day,
-                                hour=result.hour,
-                                minute=result.minute,
-                                second=result.second,
-                                tzinfo=result.tzinfo,
-                                frac_second=result_frac_second,
-                                frac_second_exponent=result_frac_second_exponent)
+            return DateTime(year=result.year,
+                            month=result.month,
+                            day=result.day,
+                            hour=result.hour,
+                            minute=result.minute,
+                            second=result.second,
+                            tzinfo=result.tzinfo,
+                            frac_second=result_frac_second,
+                            frac_second_exponent=result_frac_second_exponent)
 
         return NotImplemented
 
     __radd__ = __add__
 
     def __sub__(self, other):
-        if isinstance(other, Highdatetime) or isinstance(other, datetime):
+        if isinstance(other, DateTime) or isinstance(other, datetime):
             return self.__subtract_highdatetime__(self, other)
         return NotImplemented
 
     def __rsub__(self, other):
-        if isinstance(other, Highdatetime) or isinstance(other, datetime):
+        if isinstance(other, DateTime) or isinstance(other, datetime):
             return self.__subtract_highdatetime__(other, self)
         return NotImplemented
 
@@ -251,7 +251,7 @@ class Highdatetime(object):
                 frac_second=None, frac_second_exponent=None,
                 **kwargs):
         """
-        Return a new Highdatetime with new values for the specified fields.
+        Return a new DateTime with new values for the specified fields.
         """
         # Same args as __new__, see note about "fold" in __new__
         if util.isPython36Compat:
@@ -283,11 +283,11 @@ class Highdatetime(object):
         if util.isPython36Compat:
             if fold is None:
                 fold = self.fold
-            return Highdatetime(year, month, day, hour, minute, second,
-                                microsecond, tzinfo, fold=fold)
+            return DateTime(year, month, day, hour, minute, second,
+                            microsecond, tzinfo, fold=fold)
         else:
-            return Highdatetime(year, month, day, hour, minute, second,
-                                microsecond, tzinfo)
+            return DateTime(year, month, day, hour, minute, second,
+                            microsecond, tzinfo)
 
     def weekday(self):
         return self._datetime.weekday()
@@ -348,37 +348,37 @@ class Highdatetime(object):
         assert isinstance(dt, datetime)
 
         if util.isPython36Compat:
-            return Highdatetime(dt.year, dt.month, dt.day,
-                                dt.hour, dt.minute, dt.second,
-                                dt.microsecond, dt.tzinfo, fold=dt.fold)
+            return DateTime(dt.year, dt.month, dt.day,
+                            dt.hour, dt.minute, dt.second,
+                            dt.microsecond, dt.tzinfo, fold=dt.fold)
         else:
-            return Highdatetime(dt.year, dt.month, dt.day,
-                                dt.hour, dt.minute, dt.second,
-                                dt.microsecond, dt.tzinfo)
+            return DateTime(dt.year, dt.month, dt.day,
+                            dt.hour, dt.minute, dt.second,
+                            dt.microsecond, dt.tzinfo)
 
     @staticmethod
     def fromtimestamp(t, tz=None):
-        return Highdatetime.fromdatetime(datetime.fromtimestamp(t, tz))
+        return DateTime.fromdatetime(datetime.fromtimestamp(t, tz))
 
     @staticmethod
     def utcfromtimestamp(t):
-        return Highdatetime.fromdatetime(datetime.utcfromtimestamp(t))
+        return DateTime.fromdatetime(datetime.utcfromtimestamp(t))
 
     @staticmethod
     def today():
-        return Highdatetime.fromdatetime(datetime.today())
+        return DateTime.fromdatetime(datetime.today())
 
     @staticmethod
     def now(tz=None):
-        return Highdatetime.fromdatetime(datetime.now(tz))
+        return DateTime.fromdatetime(datetime.now(tz))
 
     @staticmethod
     def utcnow():
-        return Highdatetime.fromdatetime(datetime.utcnow())
+        return DateTime.fromdatetime(datetime.utcnow())
 
     @staticmethod
     def fromordinal(ordinal):
-        return Highdatetime.fromdatetime(datetime.fromordinal(ordinal))
+        return DateTime.fromdatetime(datetime.fromordinal(ordinal))
 
     @staticmethod
     def combine(date, time, tzinfo=None):
@@ -387,18 +387,18 @@ class Highdatetime(object):
         elif not util.isPython36Compat:
             raise TypeError  # FIXME, support this
         if util.isPython36Compat:
-            return Highdatetime.fromdatetime(datetime.combine(date, time, tzinfo))
+            return DateTime.fromdatetime(datetime.combine(date, time, tzinfo))
         else:
-            return Highdatetime.fromdatetime(datetime.combine(date, time))
+            return DateTime.fromdatetime(datetime.combine(date, time))
 
     @staticmethod
     def strptime(date_string, format):
-        return Highdatetime.fromdatetime(datetime.strptime(date_string, format))
+        return DateTime.fromdatetime(datetime.strptime(date_string, format))
 
     @staticmethod
     def __subtract_highdatetime__(a, b):
-        assert (isinstance(a, datetime) or isinstance(a, Highdatetime)) and \
-               (isinstance(b, datetime) or isinstance(b, Highdatetime))
+        assert (isinstance(a, datetime) or isinstance(a, DateTime)) and \
+               (isinstance(b, datetime) or isinstance(b, DateTime))
 
         # Subtract values without sub-seconds, then deal with normalized
         # sub-seconds separately.
@@ -427,15 +427,15 @@ class Highdatetime(object):
             result_frac_seconds = ((10 ** abs(result_frac_seconds_exponent)) +
                                    result_frac_seconds)
 
-        return Hightimedelta(days=result.days,
-                             seconds=result.seconds,
-                             frac_seconds=result_frac_seconds,
-                             frac_seconds_exponent=result_frac_seconds_exponent)
+        return TimeDelta(days=result.days,
+                         seconds=result.seconds,
+                         frac_seconds=result_frac_seconds,
+                         frac_seconds_exponent=result_frac_seconds_exponent)
 
 
 # Import hightimedelta module here to avoid circular import problems related to
-# the definition of the Highdatetime class above.
-from .hightimedelta import Hightimedelta  # noqa: E402
+# the definition of the DateTime class above.
+from .hightimedelta import TimeDelta  # noqa: E402
 
 if(util.isPython3Compat):
     long = int

--- a/hightime/hightimedelta.py
+++ b/hightime/hightimedelta.py
@@ -4,11 +4,11 @@ from . import util
 from .sitimeunit import SITimeUnit
 
 
-class Hightimedelta(object):
+class TimeDelta(object):
 
     __slots__ = '_timedelta', '_frac_seconds', '_frac_seconds_exponent'
 
-    # Hightimedelta resolution is virtually infinite, None represents infinity?
+    # TimeDelta resolution is virtually infinite, None represents infinity?
     resolution = None
     min = timedelta.min
     max = timedelta.max
@@ -116,13 +116,13 @@ class Hightimedelta(object):
     def __repr__(self):
         """Convert to formal string, for repr()."""
         if self._frac_seconds == 0:
-            return super(Hightimedelta, self).__repr__()
+            return super(TimeDelta, self).__repr__()
         return "%s(%d, %d, frac_seconds=%d, frac_seconds_exponent=%d)" \
             % (self.__class__.__name__, self.days,
                self.seconds, self.frac_seconds, self.frac_seconds_exponent)
 
     def __eq__(self, other):
-        if isinstance(other, Hightimedelta) or isinstance(other, timedelta):
+        if isinstance(other, TimeDelta) or isinstance(other, timedelta):
             # check sub-second value first since that is more likely different.
             (frac_second,
              other_frac_second,
@@ -139,12 +139,12 @@ class Hightimedelta(object):
         return False
 
     def __add__(self, other):
-        # Highdatetime already handles adding Hightimedelta objs
-        if isinstance(other, Highdatetime):
+        # DateTime already handles adding TimeDelta objs
+        if isinstance(other, DateTime):
             return other + self
         elif isinstance(other, datetime):
-            return Highdatetime.fromdatetime(other) + self
-        elif isinstance(other, Hightimedelta) or isinstance(other, timedelta):
+            return DateTime.fromdatetime(other) + self
+        elif isinstance(other, TimeDelta) or isinstance(other, timedelta):
             # add values without sub-seconds, then deal with normalized
             # sub-seconds separately.
             whole_seconds_self = timedelta(seconds=int(self.total_seconds()))
@@ -167,10 +167,10 @@ class Hightimedelta(object):
                 result = timedelta.__sub__(result, timedelta(seconds=1))
                 result_frac_seconds += 10 ** abs(result_frac_seconds_exponent)
 
-            return Hightimedelta(days=result.days,
-                                 seconds=result.seconds,
-                                 frac_seconds=result_frac_seconds,
-                                 frac_seconds_exponent=result_frac_seconds_exponent)
+            return TimeDelta(days=result.days,
+                             seconds=result.seconds,
+                             frac_seconds=result_frac_seconds,
+                             frac_seconds_exponent=result_frac_seconds_exponent)
 
         return NotImplemented
 
@@ -197,10 +197,10 @@ class Hightimedelta(object):
                 result_frac_seconds += ((10 ** abs(self.frac_seconds_exponent)) *
                                         num_extra_seconds)
 
-            return Hightimedelta(days=result.days,
-                                 seconds=result.seconds,
-                                 frac_seconds=result_frac_seconds,
-                                 frac_seconds_exponent=self.frac_seconds_exponent)
+            return TimeDelta(days=result.days,
+                             seconds=result.seconds,
+                             frac_seconds=result_frac_seconds,
+                             frac_seconds_exponent=self.frac_seconds_exponent)
 
         if isinstance(other, float):
             return NotImplemented  # FIXME
@@ -211,8 +211,8 @@ class Hightimedelta(object):
 
 
 # Import highdatetime module here to avoid circular import problems related to
-# the definition of the Hightimedelta class above.
-from .highdatetime import Highdatetime  # noqa: E402
+# the definition of the TimeDelta class above.
+from .highdatetime import DateTime  # noqa: E402
 
 if(util.isPython3Compat):
     long = int

--- a/hightime/test/test_highdatetime.py
+++ b/hightime/test/test_highdatetime.py
@@ -5,8 +5,8 @@ import datetime
 
 from .. import (
     SITimeUnit,
-    Highdatetime,
-    Hightimedelta,
+    DateTime,
+    TimeDelta,
 )
 
 
@@ -15,198 +15,198 @@ _isPython36Compat = (_isPython3Compat and (sys.version_info.minor >= 6))
 _isPython2Compat = (sys.version_info.major == 2)
 
 
-class HighdatetimeTestCase(unittest.TestCase):
+class DateTimeTestCase(unittest.TestCase):
 
     @unittest.skipIf(not(_isPython36Compat),
                      "not supported in this version of Python")
     def test_datetimePy36CompatibleCtor(self):
-        Highdatetime(year=1, month=1, day=1, hour=1, minute=1, second=1,
+        DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
                      microsecond=1, tzinfo=None, fold=1)
 
     @unittest.skipIf(_isPython36Compat,
                      "not supported in this version of Python")
     def test_datetimeCompatibleCtor(self):
-        Highdatetime(year=1, month=1, day=1, hour=1, minute=1, second=1,
+        DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
                      microsecond=1, tzinfo=None)
 
     def test_basicCtor(self):
-        Highdatetime(year=1, month=1, day=1,
+        DateTime(year=1, month=1, day=1,
                      frac_second=1, frac_second_exponent=SITimeUnit.NANOSECONDS)
 
     def test_ctorInvalidKWArgs(self):
         with self.assertRaises(TypeError):
-            Highdatetime(year=1, month=1, day=1, somethingelse=4, frac_second=1)
+            DateTime(year=1, month=1, day=1, somethingelse=4, frac_second=1)
 
     def test_ctorBadType(self):
         with self.assertRaises(TypeError):
-            Highdatetime(year=1, month=1, day=1, frac_second="")
+            DateTime(year=1, month=1, day=1, frac_second="")
         with self.assertRaises(TypeError):
-            Highdatetime(year=1, month=1, day=1, microsecond="")
+            DateTime(year=1, month=1, day=1, microsecond="")
 
     def test_repr(self):
-        hdt = Highdatetime(year=1, month=1, day=1, second=1, microsecond=1)
+        hdt = DateTime(year=1, month=1, day=1, second=1, microsecond=1)
         self.assertEqual(hdt, eval(repr(hdt)))
-        hdt = Highdatetime(year=1, month=1, day=1, second=1,
+        hdt = DateTime(year=1, month=1, day=1, second=1,
                            frac_second=1, frac_second_exponent=-1)
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_nanosecondDefaultFracSecondExponent(self):
-        hdt = Highdatetime(year=1, month=1, day=1, frac_second=1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1)
 
     def test_highdatetimeEqual(self):
-        hdt1 = Highdatetime(year=1, month=1, day=1, frac_second=1)
-        hdt2 = Highdatetime(year=1, month=1, day=1, frac_second=1)
+        hdt1 = DateTime(year=1, month=1, day=1, frac_second=1)
+        hdt2 = DateTime(year=1, month=1, day=1, frac_second=1)
         self.assertEqual(hdt1, hdt2)
 
     def test_highdatetimeEqualDatetime(self):
         dt = datetime.datetime(year=1, month=1, day=1)
-        hdt = Highdatetime(year=1, month=1, day=1)
+        hdt = DateTime(year=1, month=1, day=1)
         self.assertEqual(dt, hdt)
 
     def test_highdatetimeWithFracEqualDatetime(self):
         dt = datetime.datetime(year=1, month=1, day=1, microsecond=1)
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            frac_second=1, frac_second_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(dt, hdt)
 
-        hdt = Highdatetime(year=1, month=1, day=1, microsecond=1)
+        hdt = DateTime(year=1, month=1, day=1, microsecond=1)
         self.assertEqual(dt, hdt)
 
     def test_highdatetimeNotEqual(self):
-        hdt1 = Highdatetime(year=1, month=1, day=1, frac_second=1)
-        hdt2 = Highdatetime(year=1, month=1, day=1, frac_second=2)
+        hdt1 = DateTime(year=1, month=1, day=1, frac_second=1)
+        hdt2 = DateTime(year=1, month=1, day=1, frac_second=2)
         self.assertNotEqual(hdt1, hdt2)
 
     def test_highdatetimeNotEqualDatetime(self):
         dt = datetime.datetime(year=1, month=1, day=1)
-        hdt = Highdatetime(year=1, month=1, day=1, frac_second=1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1)
         self.assertNotEqual(dt, hdt)
 
     def test_highdatetimeMinAttr(self):
-        self.assertEqual(Highdatetime.min, datetime.datetime.min)
+        self.assertEqual(DateTime.min, datetime.datetime.min)
 
     def test_highdatetimeMaxAttr(self):
-        # Highdatetime.max could be higher than datetime.max, but not easy to
+        # DateTime.max could be higher than datetime.max, but not easy to
         # represent the actual max due to the virtually-infinite about of
         # sub-microseconds that can be represented. Just re-use datetime.max?
-        self.assertEqual(Highdatetime.max, datetime.datetime.max)
+        self.assertEqual(DateTime.max, datetime.datetime.max)
 
     def test_highdatetimeResolutionAttr(self):
-        # Highdatetime resolution is virtually infinite. Return None to
+        # DateTime resolution is virtually infinite. Return None to
         # represent infinity?
-        self.assertEqual(Highdatetime.resolution, None)
+        self.assertEqual(DateTime.resolution, None)
 
     def test_highdatetimeFracsecondAttr(self):
-        hdt = Highdatetime(year=1, month=1, day=1, hour=1, minute=1, second=1,
+        hdt = DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
                            frac_second=1, frac_second_exponent=-9)
         self.assertEqual(hdt.frac_second, 1)
         self.assertEqual(hdt.frac_second_exponent, -9)
 
     def test_highdatetimeFracsecondFracsecondexponentAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          microsecond=1, frac_second=1, frac_second_exponent=-1)
         self.assertEqual(exc.exception.args,
                          ("Cannot specify both microsecond and frac_second",))
 
     def test_highdatetimeFracsecondAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          microsecond=1, frac_second=1)
         self.assertEqual(exc.exception.args,
                          ("Cannot specify both microsecond and frac_second",))
 
     def test_highdatetimeFracsecondExponentAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          microsecond=1, frac_second_exponent=-1)
         self.assertEqual(exc.exception.args,
                          ("Cannot specify both microsecond and frac_second_exponent",))
 
     def test_highdatetimePositiveFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          frac_second=1, frac_second_exponent=1)
         self.assertEqual(exc.exception.args,
                          ("frac_second_exponent must be a negative long/int", 1))
 
     def test_highdatetimeFloatFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          frac_second=1, frac_second_exponent=-1.1)
         self.assertEqual(exc.exception.args,
                          ("frac_second_exponent must be a negative long/int", -1.1))
 
     def test_highdatetimeNonNumFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          frac_second=1, frac_second_exponent="1")
         self.assertEqual(exc.exception.args,
                          ("frac_second_exponent must be a negative long/int", "1"))
 
     def test_highdatetimeFracsecondGreaterThanSecond(self):
         with self.assertRaises(ValueError) as exc:
-            Highdatetime(year=1, month=1, day=1,
+            DateTime(year=1, month=1, day=1,
                          frac_second=11, frac_second_exponent=-1)
         self.assertEqual(exc.exception.args,
                          ("total fractional seconds >= 1 second", 1.1))
         with self.assertRaises(ValueError) as exc:
-            Highdatetime(year=1, month=1, day=1, microsecond=1000000)
+            DateTime(year=1, month=1, day=1, microsecond=1000000)
         self.assertEqual(exc.exception.args,
                          ("total fractional seconds >= 1 second", 1.0))
 
     def test_highdatetimeFracSecondStr(self):
-        hdt = Highdatetime(year=1, month=1, day=1, microsecond=1)
+        hdt = DateTime(year=1, month=1, day=1, microsecond=1)
         self.assertEqual("0001-01-01 00:00:00.000001", str(hdt))
 
         # default frac_second_exponent
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            hour=1, minute=1, second=1,
                            frac_second=1)
         self.assertEqual("0001-01-01 01:01:01+1e-9", str(hdt))
         # frac_second_exponent that should not use sci notation
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            hour=1, minute=1, second=1,
                            frac_second=1, frac_second_exponent=-5)
         self.assertEqual("0001-01-01 01:01:01.00001", str(hdt))
         # very small frac_second_exponent
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            hour=1, minute=1, second=1,
                            frac_second=1, frac_second_exponent=-9999999)
         self.assertEqual("0001-01-01 01:01:01+1e-9999999", str(hdt))
 
-    def test_highdatetimeSubtractHighdatetime(self):
-        hdt1 = Highdatetime(year=1, month=1, day=1,
+    def test_highdatetimeSubtractDateTime(self):
+        hdt1 = DateTime(year=1, month=1, day=1,
                             frac_second=1, frac_second_exponent=-1)
-        hdt2 = Highdatetime(year=1, month=1, day=1,
+        hdt2 = DateTime(year=1, month=1, day=1,
                             frac_second=2, frac_second_exponent=-1)
 
-        expected = Hightimedelta(frac_seconds=1, frac_seconds_exponent=-1)
+        expected = TimeDelta(frac_seconds=1, frac_seconds_exponent=-1)
         actual = hdt2 - hdt1
         self.assertEqual(expected, actual)
 
-        expected = Hightimedelta(frac_seconds=-1, frac_seconds_exponent=-1)
+        expected = TimeDelta(frac_seconds=-1, frac_seconds_exponent=-1)
         actual = hdt1 - hdt2
         self.assertEqual(expected, actual)
 
-        expected = Hightimedelta(frac_seconds=0)
+        expected = TimeDelta(frac_seconds=0)
         actual = hdt1 - hdt1
         self.assertEqual(expected, actual)
 
     def test_highdatetimeSubtractDatetime(self):
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            frac_second=1, frac_second_exponent=-1)
         dt = datetime.datetime(year=1, month=1, day=1)
-        expected = Hightimedelta(frac_seconds=1, frac_seconds_exponent=-1)
+        expected = TimeDelta(frac_seconds=1, frac_seconds_exponent=-1)
         actual = hdt - dt
         self.assertEqual(expected, actual)
 
-        expected = Hightimedelta(frac_seconds=-1, frac_seconds_exponent=-1)
+        expected = TimeDelta(frac_seconds=-1, frac_seconds_exponent=-1)
         actual = dt - hdt
         self.assertEqual(expected, actual)
 
     def test_highdatetimeAddDatetime(self):
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            frac_second=1, frac_second_exponent=-1)
         dt = datetime.datetime(year=1, month=1, day=1)
         with self.assertRaises(TypeError) as exc:
@@ -215,10 +215,10 @@ class HighdatetimeTestCase(unittest.TestCase):
             result = dt + hdt
 
     def test_highdatetimeAddTimedelta(self):
-        hdt = Highdatetime(year=1, month=1, day=1,
+        hdt = DateTime(year=1, month=1, day=1,
                            frac_second=1, frac_second_exponent=-1)
         td = datetime.timedelta(seconds=1, microseconds=1)
-        expected = Highdatetime(year=1, month=1, day=1, second=1,
+        expected = DateTime(year=1, month=1, day=1, second=1,
                                 frac_second=100001,
                                 frac_second_exponent=SITimeUnit.MICROSECONDS)
         actual = hdt + td
@@ -227,17 +227,17 @@ class HighdatetimeTestCase(unittest.TestCase):
         self.assertEqual(expected, actual)
 
         # ensure proper rollover to the next second
-        hdt2 = Highdatetime(year=1, month=1, day=1,
+        hdt2 = DateTime(year=1, month=1, day=1,
                             frac_second=999999,
                             frac_second_exponent=SITimeUnit.MICROSECONDS)
-        expected = Highdatetime(year=1, month=1, day=1, second=2,
+        expected = DateTime(year=1, month=1, day=1, second=2,
                                 frac_second=0,
                                 frac_second_exponent=SITimeUnit.MICROSECONDS)
         actual = hdt2 + td
         self.assertEqual(expected, actual)
 
         td2 = datetime.timedelta(seconds=1, microseconds=2)
-        expected = Highdatetime(year=1, month=1, day=1, second=2,
+        expected = DateTime(year=1, month=1, day=1, second=2,
                                 frac_second=1,
                                 frac_second_exponent=SITimeUnit.MICROSECONDS)
         actual = hdt2 + td2
@@ -247,17 +247,17 @@ class HighdatetimeTestCase(unittest.TestCase):
     def test_highdatetimeAddNegativeTimedelta(self):
         """FIXME: this needs to work"""
         # ensure negative deltas are subtracted
-        hdt = Highdatetime(year=1, month=1, day=1, microsecond=1)
+        hdt = DateTime(year=1, month=1, day=1, microsecond=1)
         td = datetime.timedelta(microseconds=-1)
-        expected = Highdatetime(year=1, month=1, day=1)
+        expected = DateTime(year=1, month=1, day=1)
         actual = hdt + td
         self.assertEqual(expected, actual)
 
-    def test_highdatetimeAddHightimedelta(self):
-        hdt = Highdatetime(year=1, month=1, day=1,
+    def test_highdatetimeAddTimeDelta(self):
+        hdt = DateTime(year=1, month=1, day=1,
                            frac_second=1, frac_second_exponent=-1)
-        htd = Hightimedelta(seconds=1, frac_seconds=1, frac_seconds_exponent=-2)
-        expected = Highdatetime(year=1, month=1, day=1, second=1,
+        htd = TimeDelta(seconds=1, frac_seconds=1, frac_seconds_exponent=-2)
+        expected = DateTime(year=1, month=1, day=1, second=1,
                                 frac_second=11, frac_second_exponent=-2)
         actual = hdt + htd
         self.assertEqual(expected, actual)
@@ -265,28 +265,28 @@ class HighdatetimeTestCase(unittest.TestCase):
         self.assertEqual(expected, actual)
 
         # ensure proper rollover to the next second
-        hdt2 = Highdatetime(year=1, month=1, day=1,
+        hdt2 = DateTime(year=1, month=1, day=1,
                             frac_second=999999,
                             frac_second_exponent=SITimeUnit.MICROSECONDS)
-        htd2 = Hightimedelta(seconds=1, frac_seconds=1,
+        htd2 = TimeDelta(seconds=1, frac_seconds=1,
                              frac_seconds_exponent=SITimeUnit.MICROSECONDS)
-        expected = Highdatetime(year=1, month=1, day=1, second=2,
+        expected = DateTime(year=1, month=1, day=1, second=2,
                                 frac_second=0,
                                 frac_second_exponent=SITimeUnit.MICROSECONDS)
         actual = hdt2 + htd2
         self.assertEqual(expected, actual)
 
-        htd3 = Hightimedelta(seconds=1, frac_seconds=999999,
+        htd3 = TimeDelta(seconds=1, frac_seconds=999999,
                              frac_seconds_exponent=SITimeUnit.MICROSECONDS)
-        expected = Highdatetime(year=1, month=1, day=1, second=2,
+        expected = DateTime(year=1, month=1, day=1, second=2,
                                 frac_second=999998,
                                 frac_second_exponent=SITimeUnit.MICROSECONDS)
         actual = hdt2 + htd3
         self.assertEqual(expected, actual)
 
-    def test_highdatetimeAddSubtractSmallHightimedelta(self):
-        now = Highdatetime.now()
-        increment = Hightimedelta(frac_seconds=135, frac_seconds_exponent=-13)
+    def test_highdatetimeAddSubtractSmallTimeDelta(self):
+        now = DateTime.now()
+        increment = TimeDelta(frac_seconds=135, frac_seconds_exponent=-13)
         later = now + increment
         self.assertNotEqual(now, later)
         before = later
@@ -295,76 +295,76 @@ class HighdatetimeTestCase(unittest.TestCase):
         self.assertEqual(increment, later-before)
 
     def test_microsecondProp(self):
-        hdt = Highdatetime(1, 1, 1)
+        hdt = DateTime(1, 1, 1)
         self.assertEqual(hdt.microsecond, 0)
-        hdt = Highdatetime(1, 1, 1, microsecond=1)
+        hdt = DateTime(1, 1, 1, microsecond=1)
         self.assertEqual(hdt.microsecond, 1)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(hdt.microsecond, 1)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.MILLISECONDS)
         self.assertEqual(hdt.microsecond, 1000)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(hdt.microsecond, 0)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1111,
                            frac_second_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(hdt.microsecond, 1)
 
     def test_nanosecondProp(self):
-        hdt = Highdatetime(1, 1, 1)
+        hdt = DateTime(1, 1, 1)
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(hdt.nanosecond, 1)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1,
                            frac_second_exponent=SITimeUnit.PICOSECONDS)
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = Highdatetime(1, 1, 1,
+        hdt = DateTime(1, 1, 1,
                            frac_second=1111,
                            frac_second_exponent=SITimeUnit.PICOSECONDS)
         self.assertEqual(hdt.nanosecond, 1)
 
     def test_fromtimestamp(self):
         t = time.time()
-        hdt = Highdatetime.fromtimestamp(t)
-        self.assertTrue(isinstance(hdt, Highdatetime))
+        hdt = DateTime.fromtimestamp(t)
+        self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_utcfromtimestamp(self):
         t = time.time()
-        hdt = Highdatetime.utcfromtimestamp(t)
-        self.assertTrue(isinstance(hdt, Highdatetime))
+        hdt = DateTime.utcfromtimestamp(t)
+        self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_now(self):
-        hdt = Highdatetime.now()
-        self.assertTrue(isinstance(hdt, Highdatetime))
+        hdt = DateTime.now()
+        self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_utcnow(self):
-        hdt = Highdatetime.utcnow()
-        self.assertTrue(isinstance(hdt, Highdatetime))
+        hdt = DateTime.utcnow()
+        self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_combine(self):
         d = datetime.date(1, 1, 1)
         t = datetime.time(1)
-        hdt = Highdatetime.combine(d, t)
-        self.assertTrue(isinstance(hdt, Highdatetime))
+        hdt = DateTime.combine(d, t)
+        self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
-        self.assertEqual(hdt, Highdatetime(1, 1, 1, 1))
+        self.assertEqual(hdt, DateTime(1, 1, 1, 1))
 
 if __name__ == "__main__":
     unittest.main()

--- a/hightime/test/test_hightimedelta.py
+++ b/hightime/test/test_hightimedelta.py
@@ -3,8 +3,8 @@ import unittest
 import datetime
 
 from .. import (
-    Hightimedelta,
-    Highdatetime,
+    TimeDelta,
+    DateTime,
     SITimeUnit,
 )
 
@@ -14,53 +14,53 @@ _isPython36Compat = (_isPython3Compat and (sys.version_info.minor >= 6))
 _isPython2Compat = (sys.version_info.major == 2)
 
 
-class HightimedeltaTestCase(unittest.TestCase):
+class TimeDeltaTestCase(unittest.TestCase):
     def test_ctorErrorChecking(self):
         # Ensure cannot mix milli/microseconds and frac_seconds
         with self.assertRaises(TypeError):
-            Hightimedelta(milliseconds=1, frac_seconds=1)
+            TimeDelta(milliseconds=1, frac_seconds=1)
         with self.assertRaises(TypeError):
-            Hightimedelta(microseconds=1, frac_seconds=1)
+            TimeDelta(microseconds=1, frac_seconds=1)
         # Ensure frac_seconds_exponent is a negative int
         with self.assertRaises(TypeError):
-            Hightimedelta(frac_seconds=1, frac_seconds_exponent=1)
+            TimeDelta(frac_seconds=1, frac_seconds_exponent=1)
         with self.assertRaises(TypeError):
-            Hightimedelta(frac_seconds=1, frac_seconds_exponent="one")
+            TimeDelta(frac_seconds=1, frac_seconds_exponent="one")
         # Ensure total frac_seconds is <1 second
         with self.assertRaises(ValueError):
-            Hightimedelta(frac_seconds=11, frac_seconds_exponent=-1)
+            TimeDelta(frac_seconds=11, frac_seconds_exponent=-1)
 
     def test_addTodatetime(self):
         dt = datetime.datetime(1,1,1)
-        htd = Hightimedelta(frac_seconds=1,
+        htd = TimeDelta(frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
-        # To support adding a Hightimedelta to a standard datetime to get a
-        # Highdatetime, the datetime object must be on the right-hand side. This
+        # To support adding a TimeDelta to a standard datetime to get a
+        # DateTime, the datetime object must be on the right-hand side. This
         # is because datetime defines a __add__ that tries to support all
         # timedelta types (including derived classes). The __radd__() on a
-        # Hightimedelta never even gets called because of this.
+        # TimeDelta never even gets called because of this.
         actual = htd + dt
-        expected = Highdatetime(1,1,1,
+        expected = DateTime(1,1,1,
                                 frac_second=1,
                                 frac_second_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(actual, expected)
 
     def test_addToTimedelta(self):
-        htd1 = Hightimedelta(1)
-        htd2 = Hightimedelta(2)
+        htd1 = TimeDelta(1)
+        htd2 = TimeDelta(2)
         actual = htd1 + htd2
-        expected = Hightimedelta(3)
+        expected = TimeDelta(3)
         self.assertEqual(actual, expected)
 
     def test_multiply(self):
         with self.assertRaises(TypeError) as exc:
-            actual = Hightimedelta(2) * Hightimedelta(2)
+            actual = TimeDelta(2) * TimeDelta(2)
 
-        htd1 = Hightimedelta(seconds=2, frac_seconds=1,
+        htd1 = TimeDelta(seconds=2, frac_seconds=1,
                              frac_seconds_exponent=SITimeUnit.MILLISECONDS)
 
         actual = htd1 * 2
-        expected = Hightimedelta(seconds=4, frac_seconds=2,
+        expected = TimeDelta(seconds=4, frac_seconds=2,
                                  frac_seconds_exponent=SITimeUnit.MILLISECONDS)
         self.assertEqual(actual, expected)
 
@@ -72,7 +72,7 @@ class HightimedeltaTestCase(unittest.TestCase):
         one_millisecond = 10**SITimeUnit.MILLISECONDS
         additional_seconds = int(one_millisecond * multiplier)
         actual = htd1 * multiplier
-        expected = Hightimedelta(seconds=(2*multiplier)+additional_seconds)
+        expected = TimeDelta(seconds=(2*multiplier)+additional_seconds)
         self.assertEqual(actual, expected)
 
         # FIXME
@@ -80,78 +80,78 @@ class HightimedeltaTestCase(unittest.TestCase):
         # one_millisecond = 10**SITimeUnit.MILLISECONDS
         # additional_seconds = int(one_millisecond * multiplier)
         # actual = htd1 * multiplier
-        # expected = Hightimedelta(seconds=(2*multiplier)+additional_seconds)
+        # expected = TimeDelta(seconds=(2*multiplier)+additional_seconds)
         # self.assertEqual(actual, expected)
 
     def test_total_seconds(self):
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(htd.total_seconds(), 86400.000001)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.total_seconds(), 86400.0)
 
     def test_highdatetimeFracSecondStr(self):
-        htd = Hightimedelta(days=1, seconds=1, microseconds=1)
+        htd = TimeDelta(days=1, seconds=1, microseconds=1)
         self.assertEqual("1 day, 0:00:01.000001", str(htd))
-        htd = Hightimedelta(days=1, seconds=1, frac_seconds=1,
+        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.MILLISECONDS)
         self.assertEqual("1 day, 0:00:01.001000", str(htd))
-        htd = Hightimedelta(days=1, seconds=1, frac_seconds=1,
+        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual("1 day, 0:00:01+1e-9", str(htd))
         # very small frac_second_exponent
-        htd = Hightimedelta(days=1, seconds=1, frac_seconds=1,
+        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
                             frac_seconds_exponent=-9999999)
         self.assertEqual("1 day, 0:00:01+1e-9999999", str(htd))
 
     def test_repr(self):
-        htd = Hightimedelta(days=1, seconds=1, microseconds=1)
+        htd = TimeDelta(days=1, seconds=1, microseconds=1)
         self.assertEqual(htd, eval(repr(htd)))
-        htd = Hightimedelta(days=1, seconds=1,
+        htd = TimeDelta(days=1, seconds=1,
                             frac_seconds=1, frac_seconds_exponent=-1)
         self.assertEqual(htd, eval(repr(htd)))
 
     def test_microsecondsProp(self):
-        htd = Hightimedelta(1)
+        htd = TimeDelta(1)
         self.assertEqual(htd.microseconds, 0)
-        htd = Hightimedelta(1, microseconds=1)
+        htd = TimeDelta(1, microseconds=1)
         self.assertEqual(htd.microseconds, 1)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(htd.microseconds, 1)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.MILLISECONDS)
         self.assertEqual(htd.microseconds, 1000)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.microseconds, 0)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1111,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.microseconds, 1)
 
     def test_nanosecondsProp(self):
-        htd = Hightimedelta(1)
+        htd = TimeDelta(1)
         self.assertEqual(htd.nanoseconds, 0)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.nanoseconds, 1)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.MICROSECONDS)
         self.assertEqual(htd.nanoseconds, 0)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.PICOSECONDS)
         self.assertEqual(htd.nanoseconds, 0)
-        htd = Hightimedelta(1,
+        htd = TimeDelta(1,
                             frac_seconds=1111,
                             frac_seconds_exponent=SITimeUnit.PICOSECONDS)
         self.assertEqual(htd.nanoseconds, 1)

--- a/hightime/util.py
+++ b/hightime/util.py
@@ -18,8 +18,8 @@ def normalize_frac_seconds(a, b):
         returns: (100, 12, -2)
     """
     # Lots of code to handle singular "second" as used in datetime and
-    # Highdatetime, and plural "seconds" as used in timedelta and
-    # Hightimedelta...
+    # DateTime, and plural "seconds" as used in timedelta and
+    # TimeDelta...
 
     if hasattr(a, "frac_second") and hasattr(a, "frac_second_exponent"):
         a_frac_seconds = a.frac_second


### PR DESCRIPTION
### What does this Pull Request accomplish?
Renamed Hightimedelta and Highdatetime to comply with PEP8.
### List issues fixed by this Pull Request below, if any.
Fix #7 
### What testing has been done?
tox with python 2.7