### PR TITLE
Fix #24: total_seconds should return fractional results

### DIFF
--- a/hightime/hightimedelta.py
+++ b/hightime/hightimedelta.py
@@ -95,7 +95,7 @@ class TimeDelta(object):
     def total_seconds(self):
         """Total seconds in the duration."""
         return (self.days * 86400) + self.seconds + \
-               (self.microseconds * (10**SITimeUnit.MICROSECONDS))
+               (self._frac_seconds * (10**self._frac_seconds_exponent))
 
     def __str__(self):
         s = str(timedelta(days=self._timedelta.days,

--- a/hightime/test/test_hightimedelta.py
+++ b/hightime/test/test_hightimedelta.py
@@ -91,7 +91,10 @@ class TimeDeltaTestCase(unittest.TestCase):
         htd = TimeDelta(1,
                             frac_seconds=1,
                             frac_seconds_exponent=SITimeUnit.NANOSECONDS)
-        self.assertEqual(htd.total_seconds(), 86400.0)
+        self.assertEqual(htd.total_seconds(), 86400.000000001)
+        htd = TimeDelta(frac_seconds=29,
+                        frac_seconds_exponent=-12)
+        self.assertEqual(htd.total_seconds(), 29E-12)
 
     def test_highdatetimeFracSecondStr(self):
         htd = TimeDelta(days=1, seconds=1, microseconds=1)


### PR DESCRIPTION
- [x] This contribution adheres to CONTRIBUTING.md.

# What does this Pull Request accomplish?
Fixes #24, by having `total_seconds` report the fractional seconds past microseconds.

# Why should this Pull Request be merged?
Fixes #24 

# What testing has been done?
Added Additional Unit Tests