### PR TITLE
Format code using black

### DIFF
--- a/hightime/__init__.py
+++ b/hightime/__init__.py
@@ -131,7 +131,7 @@ Examples:
 >>> print delta_t
 22s 130ms
 
-"""
+"""  # noqa: E501
 
 from .highdatetime import DateTime  # noqa: F401
 from .hightimedelta import TimeDelta  # noqa: F401

--- a/hightime/highdatetime.py
+++ b/hightime/highdatetime.py
@@ -5,7 +5,7 @@ from .sitimeunit import SITimeUnit
 
 class DateTime(object):
 
-    __slots__ = "_datetime", "_frac_second", "_frac_second_exponent"
+    __slots__ = ("_datetime", "_frac_second", "_frac_second_exponent")
 
     # DateTime resolution is virtually infinite, None represents infinity?
     resolution = None

--- a/hightime/highdatetime.py
+++ b/hightime/highdatetime.py
@@ -5,7 +5,7 @@ from .sitimeunit import SITimeUnit
 
 class DateTime(object):
 
-    __slots__ = '_datetime', '_frac_second', '_frac_second_exponent'
+    __slots__ = "_datetime", "_frac_second", "_frac_second_exponent"
 
     # DateTime resolution is virtually infinite, None represents infinity?
     resolution = None
@@ -46,16 +46,19 @@ class DateTime(object):
         return self._datetime.tzinfo
 
     if util.isPython36Compat:
+
         @property
         def fold(self):
             return self._datetime.fold
 
     @property
     def nanosecond(self):
-        return util.get_subsecond_component(self._frac_second,
-                                            self._frac_second_exponent,
-                                            SITimeUnit.NANOSECONDS,
-                                            SITimeUnit.MICROSECONDS)
+        return util.get_subsecond_component(
+            self._frac_second,
+            self._frac_second_exponent,
+            SITimeUnit.NANOSECONDS,
+            SITimeUnit.MICROSECONDS,
+        )
 
     @property
     def frac_second(self):
@@ -65,9 +68,20 @@ class DateTime(object):
     def frac_second_exponent(self):
         return self._frac_second_exponent
 
-    def __init__(self, year, month=None, day=None, hour=0, minute=0, second=0,
-                 microsecond=0, tzinfo=None, fold=0,
-                 frac_second=0, frac_second_exponent=None):
+    def __init__(
+        self,
+        year,
+        month=None,
+        day=None,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+        tzinfo=None,
+        fold=0,
+        frac_second=0,
+        frac_second_exponent=None,
+    ):
 
         # Not allowing both microsecond and frac_second simplifies the
         # implementation and reduces usage errors.
@@ -75,7 +89,9 @@ class DateTime(object):
             if frac_second != 0:
                 raise TypeError("Cannot specify both microsecond and frac_second")
             if frac_second_exponent is not None:
-                raise TypeError("Cannot specify both microsecond and frac_second_exponent")
+                raise TypeError(
+                    "Cannot specify both microsecond and frac_second_exponent"
+                )
             # Set frac_second members based on microsecond
             frac_second = microsecond
             frac_second_exponent = SITimeUnit.MICROSECONDS
@@ -85,38 +101,52 @@ class DateTime(object):
             # specified, frac_second_exponent must be a negative integer.
             if frac_second_exponent is None:
                 frac_second_exponent = SITimeUnit.NANOSECONDS
-            elif ((not(isinstance(frac_second_exponent, long)) and
-                   not(isinstance(frac_second_exponent, int))) or
-                  frac_second_exponent >= 0):
-                raise TypeError("frac_second_exponent must be a negative long/int",
-                                frac_second_exponent)
+            elif (
+                not (isinstance(frac_second_exponent, long))
+                and not (isinstance(frac_second_exponent, int))
+            ) or frac_second_exponent >= 0:
+                raise TypeError(
+                    "frac_second_exponent must be a negative long/int",
+                    frac_second_exponent,
+                )
 
         if frac_second != 0:
-            if ((not (isinstance(frac_second, long)) and
-                 not (isinstance(frac_second, int)))):
-                raise TypeError("fractional second must be a long/int",
-                                frac_second)
+            if not (isinstance(frac_second, long)) and not (
+                isinstance(frac_second, int)
+            ):
+                raise TypeError("fractional second must be a long/int", frac_second)
             # Ensure fractional seconds <= 1 second
             total_frac_second = frac_second * (10 ** frac_second_exponent)
             if total_frac_second >= 1:
-                raise ValueError("total fractional seconds >= 1 second",
-                                 total_frac_second)
+                raise ValueError(
+                    "total fractional seconds >= 1 second", total_frac_second
+                )
             # Set the microsecond arg for the datetime ctor based on frac_second
             if microsecond == 0:
                 microsecond = util.get_subsecond_component(
-                    frac_second, frac_second_exponent,
-                    SITimeUnit.MICROSECONDS, SITimeUnit.SECONDS)
+                    frac_second,
+                    frac_second_exponent,
+                    SITimeUnit.MICROSECONDS,
+                    SITimeUnit.SECONDS,
+                )
 
         # FIXME: deal with fold
-        self._datetime = datetime(year, month, day, hour, minute,
-                                  second, microsecond, tzinfo)
+        self._datetime = datetime(
+            year, month, day, hour, minute, second, microsecond, tzinfo
+        )
         self._frac_second = frac_second
         self._frac_second_exponent = frac_second_exponent
 
     def __repr__(self):
         """Convert to formal string, for repr()."""
-        tmp = [self.year, self.month, self.day,  # These are never zero
-               self.hour, self.minute, self.second]
+        tmp = [
+            self.year,
+            self.month,
+            self.day,  # These are never zero
+            self.hour,
+            self.minute,
+            self.second,
+        ]
         if tmp[-1] == 0:
             del tmp[-1]
         if tmp[-1] == 0:
@@ -124,8 +154,10 @@ class DateTime(object):
         s = "%s(%s)" % (self.__class__.__name__, ", ".join(map(str, tmp)))
         if self._frac_second != 0:
             assert s[-1:] == ")"
-            s = s[:-1] + ", frac_second=%d, frac_second_exponent=%d)" \
-                % (self._frac_second, self._frac_second_exponent)
+            s = s[:-1] + ", frac_second=%d, frac_second_exponent=%d)" % (
+                self._frac_second,
+                self._frac_second_exponent,
+            )
         if self.tzinfo is not None:
             assert s[-1:] == ")"
             s = s[:-1] + ", tzinfo=%r)" % self.tzinfo
@@ -140,11 +172,11 @@ class DateTime(object):
             # if not sub-usecond, use standard float format with leading &
             # trailing 0's stripped for compatibility with datetime useconds.
             if self._frac_second_exponent >= SITimeUnit.MICROSECONDS:
-                s += "{:f}".format(self._frac_second *
-                                   (10**self._frac_second_exponent)).strip("0")
+                s += "{:f}".format(
+                    self._frac_second * (10 ** self._frac_second_exponent)
+                ).strip("0")
             else:
-                s += "+{:d}e{:d}".format(self._frac_second,
-                                         self._frac_second_exponent)
+                s += "+{:d}e{:d}".format(self._frac_second, self._frac_second_exponent)
         return s
 
     def __format__(self):
@@ -178,18 +210,27 @@ class DateTime(object):
         # FIXME: is isinstance() the right way to check this?
         if isinstance(other, DateTime) or isinstance(other, datetime):
             # check sub-second value first since that is more likely different.
-            (frac_second,
-             other_frac_second,
-             frac_second_exponent) = util.normalize_frac_seconds(self, other)
+            (
+                frac_second,
+                other_frac_second,
+                frac_second_exponent,
+            ) = util.normalize_frac_seconds(self, other)
 
             if frac_second == other_frac_second:
                 # since sub-seconds equal, check the values with 0 sub-seconds
                 # using the datetime __eq__ to properly handle datetime attrs.
                 a = self.todatetime().replace(microsecond=0)
                 # FIXME: deal with fold
-                b = datetime(other.year, other.month, other.day,
-                             other.hour, other.minute, other.second,
-                             microsecond=0, tzinfo=other.tzinfo)
+                b = datetime(
+                    other.year,
+                    other.month,
+                    other.day,
+                    other.hour,
+                    other.minute,
+                    other.second,
+                    microsecond=0,
+                    tzinfo=other.tzinfo,
+                )
                 return a == b
         return False
 
@@ -203,31 +244,37 @@ class DateTime(object):
 
             result = datetime.__add__(whole_seconds_self, whole_seconds_other)
 
-            (frac_second_self, frac_second_other,
-             result_frac_second_exponent) = util.normalize_frac_seconds(self,
-                                                                        other)
+            (
+                frac_second_self,
+                frac_second_other,
+                result_frac_second_exponent,
+            ) = util.normalize_frac_seconds(self, other)
 
             result_frac_second = frac_second_self + frac_second_other
-            result_frac_second_multiplied = (result_frac_second *
-                                             (10 ** result_frac_second_exponent))
+            result_frac_second_multiplied = result_frac_second * (
+                10 ** result_frac_second_exponent
+            )
             if result_frac_second_multiplied >= 1:
                 result += timedelta(seconds=1)
                 result_frac_second -= 10 ** abs(result_frac_second_exponent)
             elif result_frac_second_multiplied < 0:
                 result -= timedelta(seconds=1)
-                result_frac_second = ((10 ** abs(result_frac_second_exponent)) +
-                                      result_frac_second)
+                result_frac_second = (
+                    10 ** abs(result_frac_second_exponent)
+                ) + result_frac_second
 
             # FIXME: fold?
-            return DateTime(year=result.year,
-                            month=result.month,
-                            day=result.day,
-                            hour=result.hour,
-                            minute=result.minute,
-                            second=result.second,
-                            tzinfo=result.tzinfo,
-                            frac_second=result_frac_second,
-                            frac_second_exponent=result_frac_second_exponent)
+            return DateTime(
+                year=result.year,
+                month=result.month,
+                day=result.day,
+                hour=result.hour,
+                minute=result.minute,
+                second=result.second,
+                tzinfo=result.tzinfo,
+                frac_second=result_frac_second,
+                frac_second_exponent=result_frac_second_exponent,
+            )
 
         return NotImplemented
 
@@ -244,12 +291,22 @@ class DateTime(object):
         return NotImplemented
 
     def __ne__(self, other):
-        return not(self.__eq__(other))
+        return not (self.__eq__(other))
 
-    def replace(self, year=None, month=None, day=None, hour=None,
-                minute=None, second=None, microsecond=None, tzinfo=True,
-                frac_second=None, frac_second_exponent=None,
-                **kwargs):
+    def replace(
+        self,
+        year=None,
+        month=None,
+        day=None,
+        hour=None,
+        minute=None,
+        second=None,
+        microsecond=None,
+        tzinfo=True,
+        frac_second=None,
+        frac_second_exponent=None,
+        **kwargs
+    ):
         """
         Return a new DateTime with new values for the specified fields.
         """
@@ -283,11 +340,11 @@ class DateTime(object):
         if util.isPython36Compat:
             if fold is None:
                 fold = self.fold
-            return DateTime(year, month, day, hour, minute, second,
-                            microsecond, tzinfo, fold=fold)
+            return DateTime(
+                year, month, day, hour, minute, second, microsecond, tzinfo, fold=fold
+            )
         else:
-            return DateTime(year, month, day, hour, minute, second,
-                            microsecond, tzinfo)
+            return DateTime(year, month, day, hour, minute, second, microsecond, tzinfo)
 
     def weekday(self):
         return self._datetime.weekday()
@@ -301,7 +358,7 @@ class DateTime(object):
     def astimezone(self, tz=None):
         return self._datetime.isocalendar(tz)
 
-    def isoformat(self, sep='T'):
+    def isoformat(self, sep="T"):
         return self._datetime.isoformat(sep)
 
     def ctime(self):
@@ -339,22 +396,44 @@ class DateTime(object):
 
     def todatetime(self):
         # FIXME: deal with fold
-        return datetime(self.year, self.month, self.day,
-                        self.hour, self.minute, self.second,
-                        self.microsecond, self.tzinfo)
+        return datetime(
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            self.second,
+            self.microsecond,
+            self.tzinfo,
+        )
 
     @staticmethod
     def fromdatetime(dt):
         assert isinstance(dt, datetime)
 
         if util.isPython36Compat:
-            return DateTime(dt.year, dt.month, dt.day,
-                            dt.hour, dt.minute, dt.second,
-                            dt.microsecond, dt.tzinfo, fold=dt.fold)
+            return DateTime(
+                dt.year,
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.minute,
+                dt.second,
+                dt.microsecond,
+                dt.tzinfo,
+                fold=dt.fold,
+            )
         else:
-            return DateTime(dt.year, dt.month, dt.day,
-                            dt.hour, dt.minute, dt.second,
-                            dt.microsecond, dt.tzinfo)
+            return DateTime(
+                dt.year,
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.minute,
+                dt.second,
+                dt.microsecond,
+                dt.tzinfo,
+            )
 
     @staticmethod
     def fromtimestamp(t, tz=None):
@@ -397,23 +476,41 @@ class DateTime(object):
 
     @staticmethod
     def __subtract_highdatetime__(a, b):
-        assert (isinstance(a, datetime) or isinstance(a, DateTime)) and \
-               (isinstance(b, datetime) or isinstance(b, DateTime))
+        assert (isinstance(a, datetime) or isinstance(a, DateTime)) and (
+            isinstance(b, datetime) or isinstance(b, DateTime)
+        )
 
         # Subtract values without sub-seconds, then deal with normalized
         # sub-seconds separately.
         # FIXME: deal with fold
-        whole_seconds_a = datetime(a.year, a.month, a.day,
-                                   a.hour, a.minute, a.second,
-                                   microsecond=0, tzinfo=a.tzinfo)
-        whole_seconds_b = datetime(b.year, b.month, b.day,
-                                   b.hour, b.minute, b.second,
-                                   microsecond=0, tzinfo=b.tzinfo)
+        whole_seconds_a = datetime(
+            a.year,
+            a.month,
+            a.day,
+            a.hour,
+            a.minute,
+            a.second,
+            microsecond=0,
+            tzinfo=a.tzinfo,
+        )
+        whole_seconds_b = datetime(
+            b.year,
+            b.month,
+            b.day,
+            b.hour,
+            b.minute,
+            b.second,
+            microsecond=0,
+            tzinfo=b.tzinfo,
+        )
 
         result = whole_seconds_a - whole_seconds_b
 
-        (frac_seconds_a, frac_seconds_b,
-         result_frac_seconds_exponent) = util.normalize_frac_seconds(a, b)
+        (
+            frac_seconds_a,
+            frac_seconds_b,
+            result_frac_seconds_exponent,
+        ) = util.normalize_frac_seconds(a, b)
 
         result_frac_seconds = frac_seconds_a - frac_seconds_b
 
@@ -424,18 +521,21 @@ class DateTime(object):
         # remainder.
         if (result > timedelta(0)) and (result_frac_seconds < 0):
             result -= timedelta(seconds=1)
-            result_frac_seconds = ((10 ** abs(result_frac_seconds_exponent)) +
-                                   result_frac_seconds)
+            result_frac_seconds = (
+                10 ** abs(result_frac_seconds_exponent)
+            ) + result_frac_seconds
 
-        return TimeDelta(days=result.days,
-                         seconds=result.seconds,
-                         frac_seconds=result_frac_seconds,
-                         frac_seconds_exponent=result_frac_seconds_exponent)
+        return TimeDelta(
+            days=result.days,
+            seconds=result.seconds,
+            frac_seconds=result_frac_seconds,
+            frac_seconds_exponent=result_frac_seconds_exponent,
+        )
 
 
 # Import hightimedelta module here to avoid circular import problems related to
 # the definition of the DateTime class above.
 from .hightimedelta import TimeDelta  # noqa: E402
 
-if(util.isPython3Compat):
+if util.isPython3Compat:
     long = int

--- a/hightime/hightimedelta.py
+++ b/hightime/hightimedelta.py
@@ -6,7 +6,7 @@ from .sitimeunit import SITimeUnit
 
 class TimeDelta(object):
 
-    __slots__ = '_timedelta', '_frac_seconds', '_frac_seconds_exponent'
+    __slots__ = "_timedelta", "_frac_seconds", "_frac_seconds_exponent"
 
     # TimeDelta resolution is virtually infinite, None represents infinity?
     resolution = None
@@ -36,24 +36,38 @@ class TimeDelta(object):
 
     @property
     def nanoseconds(self):
-        return util.get_subsecond_component(self._frac_seconds,
-                                            self._frac_seconds_exponent,
-                                            SITimeUnit.NANOSECONDS,
-                                            SITimeUnit.MICROSECONDS)
+        return util.get_subsecond_component(
+            self._frac_seconds,
+            self._frac_seconds_exponent,
+            SITimeUnit.NANOSECONDS,
+            SITimeUnit.MICROSECONDS,
+        )
 
-    def __init__(self, days=0, seconds=0, microseconds=0,
-                 milliseconds=0, minutes=0, hours=0, weeks=0,
-                 frac_seconds=0, frac_seconds_exponent=None):
+    def __init__(
+        self,
+        days=0,
+        seconds=0,
+        microseconds=0,
+        milliseconds=0,
+        minutes=0,
+        hours=0,
+        weeks=0,
+        frac_seconds=0,
+        frac_seconds_exponent=None,
+    ):
 
         # Not allowing both microseconds or milliseconds along with arbitrary
         # frac_seconds simplifies the implementation and reduces usage errors.
         if (microseconds != 0) or (milliseconds != 0):
             if frac_seconds != 0:
-                raise TypeError("Cannot specify microseconds or "
-                                "milliseconds with frac_seconds")
+                raise TypeError(
+                    "Cannot specify microseconds or " "milliseconds with frac_seconds"
+                )
             if frac_seconds_exponent is not None:
-                raise TypeError("Cannot specify microseconds or "
-                                "milliseconds with frac_seconds_exponent")
+                raise TypeError(
+                    "Cannot specify microseconds or "
+                    "milliseconds with frac_seconds_exponent"
+                )
 
             # Set frac_second members based on microsecond or milliseconds,
             # normalize to microseconds
@@ -66,15 +80,21 @@ class TimeDelta(object):
             # integer.
             if frac_seconds_exponent is None:
                 frac_seconds_exponent = SITimeUnit.NANOSECONDS
-            elif ((not (isinstance(frac_seconds_exponent, long)) and
-                   not (isinstance(frac_seconds_exponent, int))) or
-                  frac_seconds_exponent >= 0):
-                raise TypeError("frac_seconds_exponent must be a negative long/int",
-                                frac_seconds_exponent)
+            elif (
+                not (isinstance(frac_seconds_exponent, long))
+                and not (isinstance(frac_seconds_exponent, int))
+            ) or frac_seconds_exponent >= 0:
+                raise TypeError(
+                    "frac_seconds_exponent must be a negative long/int",
+                    frac_seconds_exponent,
+                )
             # Set the microseconds arg for the timedelta ctor based on frac_second
             microseconds = util.get_subsecond_component(
-                frac_seconds, frac_seconds_exponent,
-                SITimeUnit.MICROSECONDS, SITimeUnit.SECONDS)
+                frac_seconds,
+                frac_seconds_exponent,
+                SITimeUnit.MICROSECONDS,
+                SITimeUnit.SECONDS,
+            )
 
         if frac_seconds != 0:
             # if (not(isinstance(frac_second, long)) and \
@@ -84,57 +104,67 @@ class TimeDelta(object):
             # Ensure fractional seconds <= 1 second
             total_frac_seconds = frac_seconds * (10 ** frac_seconds_exponent)
             if total_frac_seconds > 1:
-                raise ValueError("total fractional seconds > 1 second",
-                                 total_frac_seconds)
+                raise ValueError(
+                    "total fractional seconds > 1 second", total_frac_seconds
+                )
 
-        self._timedelta = timedelta(days, seconds, microseconds,
-                                    milliseconds, minutes, hours, weeks)
+        self._timedelta = timedelta(
+            days, seconds, microseconds, milliseconds, minutes, hours, weeks
+        )
         self._frac_seconds = frac_seconds
         self._frac_seconds_exponent = frac_seconds_exponent
 
     def total_seconds(self):
         """Total seconds in the duration."""
-        return (self.days * 86400) + self.seconds + \
-               (self.microseconds * (10**SITimeUnit.MICROSECONDS))
+        return (
+            (self.days * 86400)
+            + self.seconds
+            + (self.microseconds * (10 ** SITimeUnit.MICROSECONDS))
+        )
 
     def __str__(self):
-        s = str(timedelta(days=self._timedelta.days,
-                          seconds=self._timedelta.seconds))
+        s = str(timedelta(days=self._timedelta.days, seconds=self._timedelta.seconds))
         # Since both microseconds and frac_seconds cannot be specified
         # together, return the default str only if not using frac_seconds
         if self._frac_seconds:
             # if not sub-usecond, use standard float format with leading 0's
             # stripped for compatibility with datetime.
             if self._frac_seconds_exponent >= SITimeUnit.MICROSECONDS:
-                s += "{:f}".format(self._frac_seconds *
-                                   (10**self._frac_seconds_exponent)).lstrip("0")
+                s += "{:f}".format(
+                    self._frac_seconds * (10 ** self._frac_seconds_exponent)
+                ).lstrip("0")
             else:
-                s += "+{:d}e{:d}".format(self._frac_seconds,
-                                         self._frac_seconds_exponent)
+                s += "+{:d}e{:d}".format(
+                    self._frac_seconds, self._frac_seconds_exponent
+                )
         return s
 
     def __repr__(self):
         """Convert to formal string, for repr()."""
         if self._frac_seconds == 0:
             return super(TimeDelta, self).__repr__()
-        return "%s(%d, %d, frac_seconds=%d, frac_seconds_exponent=%d)" \
-            % (self.__class__.__name__, self.days,
-               self.seconds, self.frac_seconds, self.frac_seconds_exponent)
+        return "%s(%d, %d, frac_seconds=%d, frac_seconds_exponent=%d)" % (
+            self.__class__.__name__,
+            self.days,
+            self.seconds,
+            self.frac_seconds,
+            self.frac_seconds_exponent,
+        )
 
     def __eq__(self, other):
         if isinstance(other, TimeDelta) or isinstance(other, timedelta):
             # check sub-second value first since that is more likely different.
-            (frac_second,
-             other_frac_second,
-             frac_seconds_exponent) = util.normalize_frac_seconds(self, other)
+            (
+                frac_second,
+                other_frac_second,
+                frac_seconds_exponent,
+            ) = util.normalize_frac_seconds(self, other)
 
             if frac_second == other_frac_second:
                 # since sub-seconds equal, check the values with 0 sub-seconds
                 # using the timedelta __eq__ to properly handle datetime attrs.
-                a = timedelta(days=self.days, seconds=self.seconds,
-                              microseconds=0)
-                b = timedelta(days=other.days, seconds=other.seconds,
-                              microseconds=0)
+                a = timedelta(days=self.days, seconds=self.seconds, microseconds=0)
+                b = timedelta(days=other.days, seconds=other.seconds, microseconds=0)
                 return timedelta.__eq__(a, b)
         return False
 
@@ -152,13 +182,16 @@ class TimeDelta(object):
 
             result = timedelta.__add__(whole_seconds_self, whole_seconds_other)
 
-            (frac_seconds_self, frac_seconds_other,
-             result_frac_seconds_exponent) = util.normalize_frac_seconds(self,
-                                                                         other)
+            (
+                frac_seconds_self,
+                frac_seconds_other,
+                result_frac_seconds_exponent,
+            ) = util.normalize_frac_seconds(self, other)
 
             result_frac_seconds = frac_seconds_self + frac_seconds_other
-            result_frac_seconds_as_seconds = (result_frac_seconds *
-                                              (10 ** result_frac_seconds_exponent))
+            result_frac_seconds_as_seconds = result_frac_seconds * (
+                10 ** result_frac_seconds_exponent
+            )
             # adjust whole seconds if necessary
             if result_frac_seconds_as_seconds >= 1:
                 result = timedelta.__add__(result, timedelta(seconds=1))
@@ -167,10 +200,12 @@ class TimeDelta(object):
                 result = timedelta.__sub__(result, timedelta(seconds=1))
                 result_frac_seconds += 10 ** abs(result_frac_seconds_exponent)
 
-            return TimeDelta(days=result.days,
-                             seconds=result.seconds,
-                             frac_seconds=result_frac_seconds,
-                             frac_seconds_exponent=result_frac_seconds_exponent)
+            return TimeDelta(
+                days=result.days,
+                seconds=result.seconds,
+                frac_seconds=result_frac_seconds,
+                frac_seconds_exponent=result_frac_seconds_exponent,
+            )
 
         return NotImplemented
 
@@ -181,26 +216,29 @@ class TimeDelta(object):
             whole_seconds_self = timedelta(seconds=int(self.total_seconds()))
             result = whole_seconds_self * other
             result_frac_seconds = self.frac_seconds * other
-            result_frac_seconds_as_seconds = (result_frac_seconds *
-                                              (10 ** self.frac_seconds_exponent))
+            result_frac_seconds_as_seconds = result_frac_seconds * (
+                10 ** self.frac_seconds_exponent
+            )
             num_extra_seconds = int(result_frac_seconds_as_seconds)
 
             # adjust whole seconds if necessary
             if num_extra_seconds >= 1:
-                result = timedelta.__add__(result,
-                                           timedelta(seconds=num_extra_seconds))
-                result_frac_seconds -= ((10 ** abs(self.frac_seconds_exponent)) *
-                                        num_extra_seconds)
+                result = timedelta.__add__(result, timedelta(seconds=num_extra_seconds))
+                result_frac_seconds -= (
+                    10 ** abs(self.frac_seconds_exponent)
+                ) * num_extra_seconds
             elif num_extra_seconds < 0:
-                result = timedelta.__sub__(result,
-                                           timedelta(seconds=num_extra_seconds))
-                result_frac_seconds += ((10 ** abs(self.frac_seconds_exponent)) *
-                                        num_extra_seconds)
+                result = timedelta.__sub__(result, timedelta(seconds=num_extra_seconds))
+                result_frac_seconds += (
+                    10 ** abs(self.frac_seconds_exponent)
+                ) * num_extra_seconds
 
-            return TimeDelta(days=result.days,
-                             seconds=result.seconds,
-                             frac_seconds=result_frac_seconds,
-                             frac_seconds_exponent=self.frac_seconds_exponent)
+            return TimeDelta(
+                days=result.days,
+                seconds=result.seconds,
+                frac_seconds=result_frac_seconds,
+                frac_seconds_exponent=self.frac_seconds_exponent,
+            )
 
         if isinstance(other, float):
             return NotImplemented  # FIXME
@@ -214,5 +252,5 @@ class TimeDelta(object):
 # the definition of the TimeDelta class above.
 from .highdatetime import DateTime  # noqa: E402
 
-if(util.isPython3Compat):
+if util.isPython3Compat:
     long = int

--- a/hightime/hightimedelta.py
+++ b/hightime/hightimedelta.py
@@ -6,7 +6,7 @@ from .sitimeunit import SITimeUnit
 
 class TimeDelta(object):
 
-    __slots__ = "_timedelta", "_frac_seconds", "_frac_seconds_exponent"
+    __slots__ = ("_timedelta", "_frac_seconds", "_frac_seconds_exponent")
 
     # TimeDelta resolution is virtually infinite, None represents infinity?
     resolution = None
@@ -61,7 +61,7 @@ class TimeDelta(object):
         if (microseconds != 0) or (milliseconds != 0):
             if frac_seconds != 0:
                 raise TypeError(
-                    "Cannot specify microseconds or " "milliseconds with frac_seconds"
+                    "Cannot specify microseconds or milliseconds with frac_seconds"
                 )
             if frac_seconds_exponent is not None:
                 raise TypeError(

--- a/hightime/test/test_highdatetime.py
+++ b/hightime/test/test_highdatetime.py
@@ -10,28 +10,47 @@ from .. import (
 )
 
 
-_isPython3Compat = (sys.version_info.major == 3)
-_isPython36Compat = (_isPython3Compat and (sys.version_info.minor >= 6))
-_isPython2Compat = (sys.version_info.major == 2)
+_isPython3Compat = sys.version_info.major == 3
+_isPython36Compat = _isPython3Compat and (sys.version_info.minor >= 6)
+_isPython2Compat = sys.version_info.major == 2
 
 
 class DateTimeTestCase(unittest.TestCase):
-
-    @unittest.skipIf(not(_isPython36Compat),
-                     "not supported in this version of Python")
+    @unittest.skipIf(not (_isPython36Compat), "not supported in this version of Python")
     def test_datetimePy36CompatibleCtor(self):
-        DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
-                     microsecond=1, tzinfo=None, fold=1)
+        DateTime(
+            year=1,
+            month=1,
+            day=1,
+            hour=1,
+            minute=1,
+            second=1,
+            microsecond=1,
+            tzinfo=None,
+            fold=1,
+        )
 
-    @unittest.skipIf(_isPython36Compat,
-                     "not supported in this version of Python")
+    @unittest.skipIf(_isPython36Compat, "not supported in this version of Python")
     def test_datetimeCompatibleCtor(self):
-        DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
-                     microsecond=1, tzinfo=None)
+        DateTime(
+            year=1,
+            month=1,
+            day=1,
+            hour=1,
+            minute=1,
+            second=1,
+            microsecond=1,
+            tzinfo=None,
+        )
 
     def test_basicCtor(self):
-        DateTime(year=1, month=1, day=1,
-                     frac_second=1, frac_second_exponent=SITimeUnit.NANOSECONDS)
+        DateTime(
+            year=1,
+            month=1,
+            day=1,
+            frac_second=1,
+            frac_second_exponent=SITimeUnit.NANOSECONDS,
+        )
 
     def test_ctorInvalidKWArgs(self):
         with self.assertRaises(TypeError):
@@ -46,8 +65,9 @@ class DateTimeTestCase(unittest.TestCase):
     def test_repr(self):
         hdt = DateTime(year=1, month=1, day=1, second=1, microsecond=1)
         self.assertEqual(hdt, eval(repr(hdt)))
-        hdt = DateTime(year=1, month=1, day=1, second=1,
-                           frac_second=1, frac_second_exponent=-1)
+        hdt = DateTime(
+            year=1, month=1, day=1, second=1, frac_second=1, frac_second_exponent=-1
+        )
         self.assertEqual(hdt, eval(repr(hdt)))
 
     def test_nanosecondDefaultFracSecondExponent(self):
@@ -65,8 +85,13 @@ class DateTimeTestCase(unittest.TestCase):
 
     def test_highdatetimeWithFracEqualDatetime(self):
         dt = datetime.datetime(year=1, month=1, day=1, microsecond=1)
-        hdt = DateTime(year=1, month=1, day=1,
-                           frac_second=1, frac_second_exponent=SITimeUnit.MICROSECONDS)
+        hdt = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            frac_second=1,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         self.assertEqual(dt, hdt)
 
         hdt = DateTime(year=1, month=1, day=1, microsecond=1)
@@ -97,89 +122,120 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertEqual(DateTime.resolution, None)
 
     def test_highdatetimeFracsecondAttr(self):
-        hdt = DateTime(year=1, month=1, day=1, hour=1, minute=1, second=1,
-                           frac_second=1, frac_second_exponent=-9)
+        hdt = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            hour=1,
+            minute=1,
+            second=1,
+            frac_second=1,
+            frac_second_exponent=-9,
+        )
         self.assertEqual(hdt.frac_second, 1)
         self.assertEqual(hdt.frac_second_exponent, -9)
 
     def test_highdatetimeFracsecondFracsecondexponentAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         microsecond=1, frac_second=1, frac_second_exponent=-1)
-        self.assertEqual(exc.exception.args,
-                         ("Cannot specify both microsecond and frac_second",))
+            DateTime(
+                year=1,
+                month=1,
+                day=1,
+                microsecond=1,
+                frac_second=1,
+                frac_second_exponent=-1,
+            )
+        self.assertEqual(
+            exc.exception.args, ("Cannot specify both microsecond and frac_second",)
+        )
 
     def test_highdatetimeFracsecondAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         microsecond=1, frac_second=1)
-        self.assertEqual(exc.exception.args,
-                         ("Cannot specify both microsecond and frac_second",))
+            DateTime(year=1, month=1, day=1, microsecond=1, frac_second=1)
+        self.assertEqual(
+            exc.exception.args, ("Cannot specify both microsecond and frac_second",)
+        )
 
     def test_highdatetimeFracsecondExponentAndMicrosecondCtor(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         microsecond=1, frac_second_exponent=-1)
-        self.assertEqual(exc.exception.args,
-                         ("Cannot specify both microsecond and frac_second_exponent",))
+            DateTime(year=1, month=1, day=1, microsecond=1, frac_second_exponent=-1)
+        self.assertEqual(
+            exc.exception.args,
+            ("Cannot specify both microsecond and frac_second_exponent",),
+        )
 
     def test_highdatetimePositiveFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         frac_second=1, frac_second_exponent=1)
-        self.assertEqual(exc.exception.args,
-                         ("frac_second_exponent must be a negative long/int", 1))
+            DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=1)
+        self.assertEqual(
+            exc.exception.args, ("frac_second_exponent must be a negative long/int", 1)
+        )
 
     def test_highdatetimeFloatFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         frac_second=1, frac_second_exponent=-1.1)
-        self.assertEqual(exc.exception.args,
-                         ("frac_second_exponent must be a negative long/int", -1.1))
+            DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1.1)
+        self.assertEqual(
+            exc.exception.args,
+            ("frac_second_exponent must be a negative long/int", -1.1),
+        )
 
     def test_highdatetimeNonNumFracsecondExponent(self):
         with self.assertRaises(TypeError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         frac_second=1, frac_second_exponent="1")
-        self.assertEqual(exc.exception.args,
-                         ("frac_second_exponent must be a negative long/int", "1"))
+            DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent="1")
+        self.assertEqual(
+            exc.exception.args,
+            ("frac_second_exponent must be a negative long/int", "1"),
+        )
 
     def test_highdatetimeFracsecondGreaterThanSecond(self):
         with self.assertRaises(ValueError) as exc:
-            DateTime(year=1, month=1, day=1,
-                         frac_second=11, frac_second_exponent=-1)
-        self.assertEqual(exc.exception.args,
-                         ("total fractional seconds >= 1 second", 1.1))
+            DateTime(year=1, month=1, day=1, frac_second=11, frac_second_exponent=-1)
+        self.assertEqual(
+            exc.exception.args, ("total fractional seconds >= 1 second", 1.1)
+        )
         with self.assertRaises(ValueError) as exc:
             DateTime(year=1, month=1, day=1, microsecond=1000000)
-        self.assertEqual(exc.exception.args,
-                         ("total fractional seconds >= 1 second", 1.0))
+        self.assertEqual(
+            exc.exception.args, ("total fractional seconds >= 1 second", 1.0)
+        )
 
     def test_highdatetimeFracSecondStr(self):
         hdt = DateTime(year=1, month=1, day=1, microsecond=1)
         self.assertEqual("0001-01-01 00:00:00.000001", str(hdt))
 
         # default frac_second_exponent
-        hdt = DateTime(year=1, month=1, day=1,
-                           hour=1, minute=1, second=1,
-                           frac_second=1)
+        hdt = DateTime(
+            year=1, month=1, day=1, hour=1, minute=1, second=1, frac_second=1
+        )
         self.assertEqual("0001-01-01 01:01:01+1e-9", str(hdt))
         # frac_second_exponent that should not use sci notation
-        hdt = DateTime(year=1, month=1, day=1,
-                           hour=1, minute=1, second=1,
-                           frac_second=1, frac_second_exponent=-5)
+        hdt = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            hour=1,
+            minute=1,
+            second=1,
+            frac_second=1,
+            frac_second_exponent=-5,
+        )
         self.assertEqual("0001-01-01 01:01:01.00001", str(hdt))
         # very small frac_second_exponent
-        hdt = DateTime(year=1, month=1, day=1,
-                           hour=1, minute=1, second=1,
-                           frac_second=1, frac_second_exponent=-9999999)
+        hdt = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            hour=1,
+            minute=1,
+            second=1,
+            frac_second=1,
+            frac_second_exponent=-9999999,
+        )
         self.assertEqual("0001-01-01 01:01:01+1e-9999999", str(hdt))
 
     def test_highdatetimeSubtractDateTime(self):
-        hdt1 = DateTime(year=1, month=1, day=1,
-                            frac_second=1, frac_second_exponent=-1)
-        hdt2 = DateTime(year=1, month=1, day=1,
-                            frac_second=2, frac_second_exponent=-1)
+        hdt1 = DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1)
+        hdt2 = DateTime(year=1, month=1, day=1, frac_second=2, frac_second_exponent=-1)
 
         expected = TimeDelta(frac_seconds=1, frac_seconds_exponent=-1)
         actual = hdt2 - hdt1
@@ -194,8 +250,7 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_highdatetimeSubtractDatetime(self):
-        hdt = DateTime(year=1, month=1, day=1,
-                           frac_second=1, frac_second_exponent=-1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1)
         dt = datetime.datetime(year=1, month=1, day=1)
         expected = TimeDelta(frac_seconds=1, frac_seconds_exponent=-1)
         actual = hdt - dt
@@ -206,8 +261,7 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_highdatetimeAddDatetime(self):
-        hdt = DateTime(year=1, month=1, day=1,
-                           frac_second=1, frac_second_exponent=-1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1)
         dt = datetime.datetime(year=1, month=1, day=1)
         with self.assertRaises(TypeError) as exc:
             result = hdt + dt
@@ -215,31 +269,49 @@ class DateTimeTestCase(unittest.TestCase):
             result = dt + hdt
 
     def test_highdatetimeAddTimedelta(self):
-        hdt = DateTime(year=1, month=1, day=1,
-                           frac_second=1, frac_second_exponent=-1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1)
         td = datetime.timedelta(seconds=1, microseconds=1)
-        expected = DateTime(year=1, month=1, day=1, second=1,
-                                frac_second=100001,
-                                frac_second_exponent=SITimeUnit.MICROSECONDS)
+        expected = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            second=1,
+            frac_second=100001,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         actual = hdt + td
         self.assertEqual(expected, actual)
         actual = td + hdt
         self.assertEqual(expected, actual)
 
         # ensure proper rollover to the next second
-        hdt2 = DateTime(year=1, month=1, day=1,
-                            frac_second=999999,
-                            frac_second_exponent=SITimeUnit.MICROSECONDS)
-        expected = DateTime(year=1, month=1, day=1, second=2,
-                                frac_second=0,
-                                frac_second_exponent=SITimeUnit.MICROSECONDS)
+        hdt2 = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            frac_second=999999,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
+        expected = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            second=2,
+            frac_second=0,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         actual = hdt2 + td
         self.assertEqual(expected, actual)
 
         td2 = datetime.timedelta(seconds=1, microseconds=2)
-        expected = DateTime(year=1, month=1, day=1, second=2,
-                                frac_second=1,
-                                frac_second_exponent=SITimeUnit.MICROSECONDS)
+        expected = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            second=2,
+            frac_second=1,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         actual = hdt2 + td2
         self.assertEqual(expected, actual)
 
@@ -254,33 +326,51 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_highdatetimeAddTimeDelta(self):
-        hdt = DateTime(year=1, month=1, day=1,
-                           frac_second=1, frac_second_exponent=-1)
+        hdt = DateTime(year=1, month=1, day=1, frac_second=1, frac_second_exponent=-1)
         htd = TimeDelta(seconds=1, frac_seconds=1, frac_seconds_exponent=-2)
-        expected = DateTime(year=1, month=1, day=1, second=1,
-                                frac_second=11, frac_second_exponent=-2)
+        expected = DateTime(
+            year=1, month=1, day=1, second=1, frac_second=11, frac_second_exponent=-2
+        )
         actual = hdt + htd
         self.assertEqual(expected, actual)
         actual = htd + hdt
         self.assertEqual(expected, actual)
 
         # ensure proper rollover to the next second
-        hdt2 = DateTime(year=1, month=1, day=1,
-                            frac_second=999999,
-                            frac_second_exponent=SITimeUnit.MICROSECONDS)
-        htd2 = TimeDelta(seconds=1, frac_seconds=1,
-                             frac_seconds_exponent=SITimeUnit.MICROSECONDS)
-        expected = DateTime(year=1, month=1, day=1, second=2,
-                                frac_second=0,
-                                frac_second_exponent=SITimeUnit.MICROSECONDS)
+        hdt2 = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            frac_second=999999,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
+        htd2 = TimeDelta(
+            seconds=1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MICROSECONDS
+        )
+        expected = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            second=2,
+            frac_second=0,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         actual = hdt2 + htd2
         self.assertEqual(expected, actual)
 
-        htd3 = TimeDelta(seconds=1, frac_seconds=999999,
-                             frac_seconds_exponent=SITimeUnit.MICROSECONDS)
-        expected = DateTime(year=1, month=1, day=1, second=2,
-                                frac_second=999998,
-                                frac_second_exponent=SITimeUnit.MICROSECONDS)
+        htd3 = TimeDelta(
+            seconds=1,
+            frac_seconds=999999,
+            frac_seconds_exponent=SITimeUnit.MICROSECONDS,
+        )
+        expected = DateTime(
+            year=1,
+            month=1,
+            day=1,
+            second=2,
+            frac_second=999998,
+            frac_second_exponent=SITimeUnit.MICROSECONDS,
+        )
         actual = hdt2 + htd3
         self.assertEqual(expected, actual)
 
@@ -292,48 +382,48 @@ class DateTimeTestCase(unittest.TestCase):
         before = later
         later += increment
         self.assertNotEqual(before, later)
-        self.assertEqual(increment, later-before)
+        self.assertEqual(increment, later - before)
 
     def test_microsecondProp(self):
         hdt = DateTime(1, 1, 1)
         self.assertEqual(hdt.microsecond, 0)
         hdt = DateTime(1, 1, 1, microsecond=1)
         self.assertEqual(hdt.microsecond, 1)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.MICROSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.MICROSECONDS
+        )
         self.assertEqual(hdt.microsecond, 1)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.MILLISECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.MILLISECONDS
+        )
         self.assertEqual(hdt.microsecond, 1000)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.NANOSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.NANOSECONDS
+        )
         self.assertEqual(hdt.microsecond, 0)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1111,
-                           frac_second_exponent=SITimeUnit.NANOSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1111, frac_second_exponent=SITimeUnit.NANOSECONDS
+        )
         self.assertEqual(hdt.microsecond, 1)
 
     def test_nanosecondProp(self):
         hdt = DateTime(1, 1, 1)
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.NANOSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.NANOSECONDS
+        )
         self.assertEqual(hdt.nanosecond, 1)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.MICROSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.MICROSECONDS
+        )
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1,
-                           frac_second_exponent=SITimeUnit.PICOSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.PICOSECONDS
+        )
         self.assertEqual(hdt.nanosecond, 0)
-        hdt = DateTime(1, 1, 1,
-                           frac_second=1111,
-                           frac_second_exponent=SITimeUnit.PICOSECONDS)
+        hdt = DateTime(
+            1, 1, 1, frac_second=1111, frac_second_exponent=SITimeUnit.PICOSECONDS
+        )
         self.assertEqual(hdt.nanosecond, 1)
 
     def test_fromtimestamp(self):
@@ -365,6 +455,7 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertTrue(isinstance(hdt, DateTime))
         self.assertEqual(hdt, eval(repr(hdt)))
         self.assertEqual(hdt, DateTime(1, 1, 1, 1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hightime/test/test_hightimedelta.py
+++ b/hightime/test/test_hightimedelta.py
@@ -9,9 +9,9 @@ from .. import (
 )
 
 
-_isPython3Compat = (sys.version_info.major == 3)
-_isPython36Compat = (_isPython3Compat and (sys.version_info.minor >= 6))
-_isPython2Compat = (sys.version_info.major == 2)
+_isPython3Compat = sys.version_info.major == 3
+_isPython36Compat = _isPython3Compat and (sys.version_info.minor >= 6)
+_isPython2Compat = sys.version_info.major == 2
 
 
 class TimeDeltaTestCase(unittest.TestCase):
@@ -31,18 +31,17 @@ class TimeDeltaTestCase(unittest.TestCase):
             TimeDelta(frac_seconds=11, frac_seconds_exponent=-1)
 
     def test_addTodatetime(self):
-        dt = datetime.datetime(1,1,1)
-        htd = TimeDelta(frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        dt = datetime.datetime(1, 1, 1)
+        htd = TimeDelta(frac_seconds=1, frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         # To support adding a TimeDelta to a standard datetime to get a
         # DateTime, the datetime object must be on the right-hand side. This
         # is because datetime defines a __add__ that tries to support all
         # timedelta types (including derived classes). The __radd__() on a
         # TimeDelta never even gets called because of this.
         actual = htd + dt
-        expected = DateTime(1,1,1,
-                                frac_second=1,
-                                frac_second_exponent=SITimeUnit.NANOSECONDS)
+        expected = DateTime(
+            1, 1, 1, frac_second=1, frac_second_exponent=SITimeUnit.NANOSECONDS
+        )
         self.assertEqual(actual, expected)
 
     def test_addToTimedelta(self):
@@ -56,12 +55,14 @@ class TimeDeltaTestCase(unittest.TestCase):
         with self.assertRaises(TypeError) as exc:
             actual = TimeDelta(2) * TimeDelta(2)
 
-        htd1 = TimeDelta(seconds=2, frac_seconds=1,
-                             frac_seconds_exponent=SITimeUnit.MILLISECONDS)
+        htd1 = TimeDelta(
+            seconds=2, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MILLISECONDS
+        )
 
         actual = htd1 * 2
-        expected = TimeDelta(seconds=4, frac_seconds=2,
-                                 frac_seconds_exponent=SITimeUnit.MILLISECONDS)
+        expected = TimeDelta(
+            seconds=4, frac_seconds=2, frac_seconds_exponent=SITimeUnit.MILLISECONDS
+        )
         self.assertEqual(actual, expected)
 
         actual = 2 * htd1
@@ -69,10 +70,10 @@ class TimeDeltaTestCase(unittest.TestCase):
 
         # resulting frac_second > 1 second
         multiplier = 1000000000
-        one_millisecond = 10**SITimeUnit.MILLISECONDS
+        one_millisecond = 10 ** SITimeUnit.MILLISECONDS
         additional_seconds = int(one_millisecond * multiplier)
         actual = htd1 * multiplier
-        expected = TimeDelta(seconds=(2*multiplier)+additional_seconds)
+        expected = TimeDelta(seconds=(2 * multiplier) + additional_seconds)
         self.assertEqual(actual, expected)
 
         # FIXME
@@ -84,34 +85,40 @@ class TimeDeltaTestCase(unittest.TestCase):
         # self.assertEqual(actual, expected)
 
     def test_total_seconds(self):
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.MICROSECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MICROSECONDS
+        )
         self.assertEqual(htd.total_seconds(), 86400.000001)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        htd = TimeDelta(1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.total_seconds(), 86400.0)
 
     def test_highdatetimeFracSecondStr(self):
         htd = TimeDelta(days=1, seconds=1, microseconds=1)
         self.assertEqual("1 day, 0:00:01.000001", str(htd))
-        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.MILLISECONDS)
+        htd = TimeDelta(
+            days=1,
+            seconds=1,
+            frac_seconds=1,
+            frac_seconds_exponent=SITimeUnit.MILLISECONDS,
+        )
         self.assertEqual("1 day, 0:00:01.001000", str(htd))
-        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        htd = TimeDelta(
+            days=1,
+            seconds=1,
+            frac_seconds=1,
+            frac_seconds_exponent=SITimeUnit.NANOSECONDS,
+        )
         self.assertEqual("1 day, 0:00:01+1e-9", str(htd))
         # very small frac_second_exponent
-        htd = TimeDelta(days=1, seconds=1, frac_seconds=1,
-                            frac_seconds_exponent=-9999999)
+        htd = TimeDelta(
+            days=1, seconds=1, frac_seconds=1, frac_seconds_exponent=-9999999
+        )
         self.assertEqual("1 day, 0:00:01+1e-9999999", str(htd))
 
     def test_repr(self):
         htd = TimeDelta(days=1, seconds=1, microseconds=1)
         self.assertEqual(htd, eval(repr(htd)))
-        htd = TimeDelta(days=1, seconds=1,
-                            frac_seconds=1, frac_seconds_exponent=-1)
+        htd = TimeDelta(days=1, seconds=1, frac_seconds=1, frac_seconds_exponent=-1)
         self.assertEqual(htd, eval(repr(htd)))
 
     def test_microsecondsProp(self):
@@ -119,39 +126,33 @@ class TimeDeltaTestCase(unittest.TestCase):
         self.assertEqual(htd.microseconds, 0)
         htd = TimeDelta(1, microseconds=1)
         self.assertEqual(htd.microseconds, 1)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.MICROSECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MICROSECONDS
+        )
         self.assertEqual(htd.microseconds, 1)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.MILLISECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MILLISECONDS
+        )
         self.assertEqual(htd.microseconds, 1000)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        htd = TimeDelta(1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.microseconds, 0)
-        htd = TimeDelta(1,
-                            frac_seconds=1111,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1111, frac_seconds_exponent=SITimeUnit.NANOSECONDS
+        )
         self.assertEqual(htd.microseconds, 1)
 
     def test_nanosecondsProp(self):
         htd = TimeDelta(1)
         self.assertEqual(htd.nanoseconds, 0)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.NANOSECONDS)
+        htd = TimeDelta(1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.NANOSECONDS)
         self.assertEqual(htd.nanoseconds, 1)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.MICROSECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.MICROSECONDS
+        )
         self.assertEqual(htd.nanoseconds, 0)
-        htd = TimeDelta(1,
-                            frac_seconds=1,
-                            frac_seconds_exponent=SITimeUnit.PICOSECONDS)
+        htd = TimeDelta(1, frac_seconds=1, frac_seconds_exponent=SITimeUnit.PICOSECONDS)
         self.assertEqual(htd.nanoseconds, 0)
-        htd = TimeDelta(1,
-                            frac_seconds=1111,
-                            frac_seconds_exponent=SITimeUnit.PICOSECONDS)
+        htd = TimeDelta(
+            1, frac_seconds=1111, frac_seconds_exponent=SITimeUnit.PICOSECONDS
+        )
         self.assertEqual(htd.nanoseconds, 1)

--- a/hightime/util.py
+++ b/hightime/util.py
@@ -2,8 +2,8 @@ import sys
 
 from .sitimeunit import SITimeUnit
 
-isPython3Compat = (sys.version_info.major == 3)
-isPython36Compat = (isPython3Compat and (sys.version_info.minor >= 6))
+isPython3Compat = sys.version_info.major == 3
+isPython36Compat = isPython3Compat and (sys.version_info.minor >= 6)
 
 
 def normalize_frac_seconds(a, b):
@@ -52,23 +52,20 @@ def normalize_frac_seconds(a, b):
         raise TypeError("invalid type for b: %s" % type(b))
 
     if a_frac_seconds_exponent == b_frac_seconds_exponent:
-        return (a_frac_seconds, b_frac_seconds,
-                a_frac_seconds_exponent)
+        return (a_frac_seconds, b_frac_seconds, a_frac_seconds_exponent)
 
-    multiplier = 10 ** (abs(a_frac_seconds_exponent -
-                            b_frac_seconds_exponent))
+    multiplier = 10 ** (abs(a_frac_seconds_exponent - b_frac_seconds_exponent))
     # a is more precise, multiply b
     if a_frac_seconds_exponent < b_frac_seconds_exponent:
-        return (a_frac_seconds, b_frac_seconds * multiplier,
-                a_frac_seconds_exponent)
+        return (a_frac_seconds, b_frac_seconds * multiplier, a_frac_seconds_exponent)
     # b is more precise, multiply a
     else:
-        return (a_frac_seconds * multiplier, b_frac_seconds,
-                b_frac_seconds_exponent)
+        return (a_frac_seconds * multiplier, b_frac_seconds, b_frac_seconds_exponent)
 
 
-def get_subsecond_component(frac_seconds, frac_seconds_exponent,
-                            subsec_component_exponent, upper_exponent_limit):
+def get_subsecond_component(
+    frac_seconds, frac_seconds_exponent, subsec_component_exponent, upper_exponent_limit
+):
     """Return the number of subseconds from frac_seconds *
     (10**frac_seconds_exponent) corresponding to subsec_component_exponent that
     does not exceed upper_exponent_limit.
@@ -85,7 +82,7 @@ def get_subsecond_component(frac_seconds, frac_seconds_exponent,
     Same example as above, but with upper_exponent_limit = SITimeUnit.SECONDS,
     123456789 would be returned.
     """
-    total_subsecs = int(frac_seconds * (10 ** (frac_seconds_exponent -
-                                               subsec_component_exponent)))
-    return total_subsecs % (10 ** abs(subsec_component_exponent -
-                                      upper_exponent_limit))
+    total_subsecs = int(
+        frac_seconds * (10 ** (frac_seconds_exponent - subsec_component_exponent))
+    )
+    return total_subsecs % (10 ** abs(subsec_component_exponent - upper_exponent_limit))

--- a/setup.py
+++ b/setup.py
@@ -11,20 +11,21 @@ class PyTest(test):
 
     def run_tests(self):
         import pytest
+
         pytest.main(self.test_args)
 
 
-pypi_name = 'hightime'
+pypi_name = "hightime"
 
 
 def read_contents(file_to_read):
-    with open(file_to_read, 'r') as f:
+    with open(file_to_read, "r") as f:
         return f.read()
 
 
 def get_version():
     script_dir = os.path.dirname(os.path.realpath(__file__))
-    version_path = os.path.join(script_dir, pypi_name, 'VERSION')
+    version_path = os.path.join(script_dir, pypi_name, "VERSION")
     return read_contents(version_path).strip()
 
 
@@ -32,20 +33,20 @@ setup(
     name=pypi_name,
     zip_safe=True,
     version=get_version(),
-    description='Hightime Python API',
-    long_description=read_contents('README.md'),
-    long_description_content_type='text/markdown',
-    author='National Instruments',
+    description="Hightime Python API",
+    long_description=read_contents("README.md"),
+    long_description_content_type="text/markdown",
+    author="National Instruments",
     author_email="opensource@ni.com",
     url="https://github.com/ni/hightime",
     maintainer="National Instruments",
     maintainer_email="opensource@ni.com",
     keywords=[pypi_name],
-    license='MIT',
+    license="MIT",
     include_package_data=True,
     packages=[pypi_name],
     install_requires=[],
-    tests_require=['pytest'],
+    tests_require=["pytest"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
@@ -62,6 +63,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    cmdclass={'test': PyTest},
-    package_data={pypi_name: ['VERSION']},
+    cmdclass={"test": PyTest},
+    package_data={pypi_name: ["VERSION"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36,37,38,py,py3}-test, flake8
+envlist = py{27,35,36,37,38,py,py3}-test, flake8, black
 skip_missing_interpreters=True
 skipsdist = true
 toxworkdir = .tox/{env:BITNESS:64}
@@ -23,6 +23,7 @@ basepython =
     pypy: pypy
     pypy3: pypy3
     flake8: python
+    black: python
 
 commands =
     test: python --version
@@ -31,12 +32,16 @@ commands =
     flake8: python --version
     flake8: python -c "import platform; print(platform.architecture())"
     flake8: flake8 {posargs}
+    black: python --version
+    black: python -c "import platform; print(platform.architecture())"
+    black: black --check . {posargs}
 
 deps =
     test-py27: enum34
     test: pytest
     test: pytest-cov
     flake8: flake8
+    black: black
 
 [pytest]
 addopts = --cov hightime --cov-report term -svv --ignore=setup.py --strict

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ addopts = --cov hightime --cov-report term -svv --ignore=setup.py --strict
 
 [flake8]
 show_source = true
-max_line_length = 120
+max_line_length = 88
 exclude = test,.eggs,.git,.tox,__pycache__
 
 # H404: Multi line docstrings should start without a leading new line.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Configures `tox` to run `black` to check the code formatting, and changes the code to adhere to `black` formatting (by running `black` on the code).

I also massaged the result to be more human-legible.

### Why should this Pull Request be merged?

`black` has become the de-facto standard for Python formatting, and for good reason. It's style minimizes diffs and is minimally configurable so discussions about configs are moot.

### What testing has been done?

Ran `tox` before changing files and saw failure. Ran it after and saw passes.
