### PR TITLE
use correct error message when out of range

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).
+- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).
 
-TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).
+TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).
 
 ### What does this Pull Request accomplish?
 

--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -26,7 +26,7 @@ def _checkArg(name, value):
                 )
 
     if not 0 <= value <= 999999999:
-        raise ValueError("{} must be in 0..999".format(name), value)
+        raise ValueError("{} must be in 0..999999999".format(name), value)
 
     return value
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses correct error message when `femtoseconds` or `yoctoseconds` are out of range. (also updating the PR template to point to the correct CONTRIBUTING.md)

### Why should this Pull Request be merged?

This makes it clearer what has gone wrong when an invalid value is passed.

### What testing has been done?

None.