### PR TITLE
hightime: Explicitly re-export the `datetime` and `timedelta` types

### DIFF
--- a/hightime/__init__.py
+++ b/hightime/__init__.py
@@ -25,6 +25,8 @@ import datetime as _std_datetime
 from hightime._datetime import datetime
 from hightime._timedelta import timedelta
 
+__all__ = ["datetime", "timedelta"]
+
 # Hide that it was defined in a helper file
 datetime.__module__ = __name__
 timedelta.__module__ = __name__

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ ignore = H404,H405,W503,W504
 [mypy]
 files = hightime/,tests/
 check_untyped_defs = true
+implicit_reexport = false
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_configs = true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use `__all__` to explicitly re-export the `datetime` and `timedelta` types.

Disable `implicit_reexport` in this project's mypy config.

### Why should this Pull Request be merged?

Without this fix, running mypy with the `--strict` or `--no-explicit-reexport` setting generates errors like this:
```
foo.py:123: error: Name "hightime.datetime" is not defined  [name-defined]
```

### What testing has been done?

Ran `tox -e mypy`.
Tested my other project that is using Mypy in strict mode.
