### PR TITLE
hightime: Remove compatibility checks for Python 3.5 and older

### DIFF
--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -1,11 +1,8 @@
 import datetime as std_datetime
-import sys
 from collections import OrderedDict
 from itertools import dropwhile
 
 import hightime
-
-_PY36 = sys.version_info >= (3, 6)
 
 
 # Mostly ripped from `datetime`'s

--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -52,7 +52,8 @@ class datetime(std_datetime.datetime):
         femtosecond=0,
         yoctosecond=0,
         tzinfo=None,
-        **kwargs
+        *,
+        fold=0,
     ):
         self = super().__new__(
             cls,
@@ -64,7 +65,7 @@ class datetime(std_datetime.datetime):
             second=second,
             microsecond=microsecond,
             tzinfo=tzinfo,
-            **kwargs
+            fold=fold,
         )
 
         femtosecond = _checkArg("femtosecond", femtosecond)
@@ -94,9 +95,7 @@ class datetime(std_datetime.datetime):
     second = std_datetime.datetime.second
     microsecond = std_datetime.datetime.microsecond
     tzinfo = std_datetime.datetime.tzinfo
-
-    if _PY36:
-        fold = std_datetime.datetime.fold
+    fold = std_datetime.datetime.fold
 
     @property
     def femtosecond(self):
@@ -153,10 +152,7 @@ class datetime(std_datetime.datetime):
                     break
 
         if timespec not in specs:
-            kwargs = dict()
-            if _PY36:
-                kwargs["timespec"] = timespec
-            return super().isoformat(sep, **kwargs)
+            return super().isoformat(sep, timespec)
 
         value = self._yoctosecond + (self._femtosecond * 1000000000)
         for spec in specs:
@@ -170,12 +166,6 @@ class datetime(std_datetime.datetime):
         iso_strs[0] += "." + fmt.format(self.microsecond, value)
         return "+".join(iso_strs)
 
-    if not _PY36:
-        _isoformat = isoformat
-
-        def isoformat(self, sep="T"):
-            return self._isoformat(sep)
-
     def replace(
         self,
         year=None,
@@ -188,7 +178,8 @@ class datetime(std_datetime.datetime):
         femtosecond=None,
         yoctosecond=None,
         tzinfo=True,
-        **kwargs
+        *,
+        fold=None,
     ):
         if year is None:
             year = self.year
@@ -210,8 +201,8 @@ class datetime(std_datetime.datetime):
             yoctosecond = self.yoctosecond
         if tzinfo is True:
             tzinfo = self.tzinfo
-        if _PY36:
-            kwargs.setdefault("fold", self.fold)
+        if fold is None:
+            fold = self.fold
         return type(self)(
             year,
             month,
@@ -223,7 +214,7 @@ class datetime(std_datetime.datetime):
             femtosecond,
             yoctosecond,
             tzinfo=tzinfo,
-            **kwargs
+            fold=fold,
         )
 
     # String operators
@@ -410,10 +401,6 @@ class datetime(std_datetime.datetime):
 
     @classmethod
     def _fromBase(cls, base_datetime):
-        ctor_kwargs = dict()
-        if _PY36:
-            ctor_kwargs = dict(fold=base_datetime.fold)
-
         return cls(
             year=base_datetime.year,
             month=base_datetime.month,
@@ -423,5 +410,5 @@ class datetime(std_datetime.datetime):
             second=base_datetime.second,
             microsecond=base_datetime.microsecond,
             tzinfo=base_datetime.tzinfo,
-            **ctor_kwargs
+            fold=base_datetime.fold,
         )

--- a/hightime/_datetime.pyi
+++ b/hightime/_datetime.pyi
@@ -27,7 +27,8 @@ class datetime(std_datetime.datetime):
         second: SupportsIndex,
         microsecond: SupportsIndex,
         tzinfo: Optional[std_datetime._TzInfo],
-        **kwargs: Any,
+        *,
+        fold: int = ...,
     ) -> datetime: ...
     @overload
     @staticmethod
@@ -43,7 +44,8 @@ class datetime(std_datetime.datetime):
         femtosecond: SupportsIndex = ...,
         yoctosecond: SupportsIndex = ...,
         tzinfo: Optional[std_datetime._TzInfo] = ...,
-        **kwargs: Any,
+        *,
+        fold: int = ...,
     ) -> datetime: ...
     @classmethod
     def __new__impl__(
@@ -58,7 +60,8 @@ class datetime(std_datetime.datetime):
         femtosecond: SupportsIndex = ...,
         yoctosecond: SupportsIndex = ...,
         tzinfo: Optional[std_datetime._TzInfo] = ...,
-        **kwargs: Any,
+        *,
+        fold: int = ...,
     ) -> datetime: ...
     def __repr__(self) -> str: ...
     @overload  # type: ignore[override]
@@ -88,7 +91,8 @@ class datetime(std_datetime.datetime):
         femtosecond: SupportsIndex = ...,
         yoctosecond: SupportsIndex = ...,
         tzinfo: Optional[std_datetime._TzInfo] = ...,
-        **kwargs: Any,
+        *,
+        fold: int = ...,
     ) -> datetime: ...
     @classmethod
     def utcfromtimestamp(cls, t: float, /) -> datetime: ...


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove checks for `sys.version_info >= (3, 6)`.

Promote `fold` to a keyword-only arg and remove kwargs from the functions that accept fold.

Add test coverage for tzinfo and fold.

### Why should this Pull Request be merged?

Improve maintainability and add test coverage.

### What testing has been done?

Ran `tox` locally:
```
Success: no issues found in 7 source files
  py39-test: OK (1.42=setup[0.08]+cmd[0.06,0.09,1.19] seconds)
  py310-test: OK (1.39=setup[0.01]+cmd[0.06,0.09,1.22] seconds)
  py311-test: OK (1.41=setup[0.03]+cmd[0.06,0.09,1.22] seconds)
  py312-test: OK (1.48=setup[0.02]+cmd[0.06,0.09,1.31] seconds)
  py313-test: OK (1.45=setup[0.06]+cmd[0.03,0.06,1.30] seconds)
  pypy-test: SKIP (0.05 seconds)
  pypy3-test: SKIP (0.03 seconds)
  flake8: OK (0.91=setup[0.03]+cmd[0.05,0.08,0.75] seconds)
  black: OK (0.52=setup[0.02]+cmd[0.05,0.09,0.36] seconds)
  mypy: OK (0.67=setup[0.00]+cmd[0.06,0.09,0.52] seconds)
  congratulations :) (9.44 seconds)
```