### PR TITLE
datetime: Fix infinite recursion with copy/pickle when running under PyPy

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13, pypy3.10, pypy3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -403,7 +403,9 @@ class datetime(std_datetime.datetime):
 
     # Pickle support
 
-    def _getstate(self, protocol=3):
+    # The pure-Python implementation of datetime.datetime has a _getstate() method. Do not override
+    # it because that would cause infinite recursion when running under PyPy.
+    def _hightime_getstate(self, protocol=3):
         reduce_value = super().__reduce_ex__(protocol)
         if not isinstance(reduce_value, tuple):
             raise TypeError(
@@ -427,7 +429,7 @@ class datetime(std_datetime.datetime):
         return (basestate,) + ctor_args[1:]
 
     def __reduce_ex__(self, protocol):
-        return (self.__class__, self._getstate(protocol))
+        return (self.__class__, self._hightime_getstate(protocol))
 
     def __reduce__(self):
         return self.__reduce_ex__(2)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Rename `datetime._getstate` to avoid overriding the superclass's `_getstate` method, only exists in the pure-Python implementation of the `datetime` module.

Update the PR workflow to run tests with `pypy3.10` and `pypy3.11`. The latest PyPy release (v7.3.19) supports Python 3.10 and 3.11.

### Why should this Pull Request be merged?

Fixes #55 

### What testing has been done?

I had a lot of trouble getting Tox to discover PyPy versions that are installed via pyenv-win.
- pyenv-win doesn't register PyPy in the Windows registry.
- Tox 4.x delegates Python interpreter discovery to virtulaenv. There is a `virtualenv-pyenv` plugin to handle this but it doesn't support PyPy.

Creating a venv with PyPy and installing Tox into it seems to work:
```
pyenv local pypy3.10-v7.3.19-win64
python -m venv .venv
.\.venv\Scripts\pip.exe install tox
.\.venv\Scripts\tox.exe -e pypy3-test
```

```
PS C:\dev\hightime> .\.venv\Scripts\tox.exe -e pypy3-test
pypy3-test: commands[0]> python --version
Python 3.10.16 (64367dfeb263, Feb 24 2025, 17:31:27)
[PyPy 7.3.19 with MSC v.1941 64 bit (AMD64)]
pypy3-test: commands[1]> python -c "import platform; print(platform.architecture())"
('64bit', 'WindowsPE')
pypy3-test: commands[2]> pytest
================================================= test session starts =================================================
platform win32 -- Python 3.10.16[pypy-7.3.19-final], pytest-8.3.5, pluggy-1.6.0 -- C:\Dev\hightime\.tox\64\pypy3-test\Scripts\python.EXE
...
=========================================== 382 passed, 1 xfailed in 5.73s ============================================
  pypy3-test: OK (7.45=setup[0.30]+cmd[0.08,0.26,6.81] seconds)
  congratulations :) (8.12 seconds)
```