### PR TITLE
Fix comparisons against unknown types

### DIFF
--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -295,10 +295,10 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
         if isinstance(other, std_datetime.datetime):
             offset_type_mismatch = ((self.utcoffset() is None) + (other.utcoffset() is None)) == 1
             return not offset_type_mismatch and not bool(self - other)
-        elif not isinstance(other, std_datetime.date):
-            return NotImplemented
-        else:
+        elif isinstance(other, std_datetime.date):
             return False
+        else:
+            return NotImplemented
 
     def __ne__(self, other):
         """Return self!=other."""
@@ -306,19 +306,31 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
 
     def __lt__(self, other):
         """Return self<other."""
-        return self._cmp(other) < 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result < 0
 
     def __le__(self, other):
         """Return self<=other."""
-        return self._cmp(other) <= 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result <= 0
 
     def __gt__(self, other):
         """Return self>other."""
-        return self._cmp(other) > 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result > 0
 
     def __ge__(self, other):
         """Return self>=other."""
-        return self._cmp(other) >= 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result >= 0
 
     # Arithmetic operators
 
@@ -465,12 +477,12 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
             if diff.days < 0:
                 return -1
             return diff and 1 or 0
-        elif not isinstance(other, std_datetime.date):
-            return NotImplemented
-        else:
+        elif isinstance(other, std_datetime.date):
             raise TypeError(
                 "can't compare '{}' to '{}'".format(type(self).__name__, type(other).__name__)
             )
+        else:
+            return NotImplemented
 
     @classmethod
     def _from_base(cls, base_datetime):

--- a/hightime/_timedelta.py
+++ b/hightime/_timedelta.py
@@ -232,10 +232,10 @@ class timedelta(std_datetime.timedelta):  # noqa: N801 - class name should use C
 
     def __eq__(self, other):
         """Return self==other."""
-        if isinstance(other, std_datetime.timedelta):
-            return _cmp(timedelta._as_tuple(self), timedelta._as_tuple(other)) == 0
-        else:
-            return False
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result == 0
 
     def __ne__(self, other):
         """Return self!=other."""
@@ -243,19 +243,31 @@ class timedelta(std_datetime.timedelta):  # noqa: N801 - class name should use C
 
     def __lt__(self, other):
         """Return self<other."""
-        return self._cmp(other) < 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result < 0
 
     def __le__(self, other):
         """Return self<=other."""
-        return self._cmp(other) <= 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result <= 0
 
     def __gt__(self, other):
         """Return self>other."""
-        return self._cmp(other) > 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result > 0
 
     def __ge__(self, other):
         """Return self>=other."""
-        return self._cmp(other) >= 0
+        result = self._cmp(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return result >= 0
 
     def __bool__(self):
         """Return bool(self)."""
@@ -380,6 +392,4 @@ class timedelta(std_datetime.timedelta):  # noqa: N801 - class name should use C
         if isinstance(other, std_datetime.timedelta):
             return _cmp(timedelta._as_tuple(self), timedelta._as_tuple(other))
         else:
-            raise TypeError(
-                "can't compare '{}' to '{}'".format(type(self).__name__, type(other).__name__)
-            )
+            return NotImplemented

--- a/tests/othertime.py
+++ b/tests/othertime.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import datetime
+from functools import total_ordering
+
+import hightime
+
+
+@total_ordering
+class OtherDateTime:
+    """Another datetime class that supports comparisons with hightime.datetime."""
+
+    def __init__(self, timestamp: float) -> None:
+        """Initialize the OtherDateTime."""
+        self._timestamp = timestamp
+
+    def __eq__(self, value: object, /) -> bool:
+        """Return self==value."""
+        if isinstance(value, OtherDateTime):
+            return self._timestamp == value._timestamp
+        elif isinstance(value, (datetime.datetime, hightime.datetime)):
+            return self._timestamp == value.timestamp()
+        else:
+            return NotImplemented
+
+    def __lt__(self, value: OtherDateTime | datetime.datetime | hightime.datetime, /) -> bool:
+        """Return self<value."""
+        if isinstance(value, OtherDateTime):
+            return self._timestamp < value._timestamp
+        elif isinstance(value, (datetime.datetime, hightime.datetime)):
+            return self._timestamp < value.timestamp()
+        else:
+            return NotImplemented  # type: ignore[unreachable]
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+        return f"{self.__class__.__name__}({self._timestamp})"
+
+
+@total_ordering
+class OtherTimeDelta:
+    """Another timedelta class that supports comparisons with hightime.timedelta."""
+
+    def __init__(self, seconds: float) -> None:
+        """Initialize the OtherTimeDelta."""
+        self._seconds = seconds
+
+    def __eq__(self, value: object, /) -> bool:
+        """Return self==value."""
+        if isinstance(value, OtherTimeDelta):
+            return self._seconds == value._seconds
+        elif isinstance(value, (datetime.timedelta, hightime.timedelta)):
+            return self._seconds == value.total_seconds()
+        else:
+            return NotImplemented
+
+    def __lt__(self, value: OtherTimeDelta | datetime.timedelta | hightime.timedelta, /) -> bool:
+        """Return self<value."""
+        if isinstance(value, OtherTimeDelta):
+            return self._seconds < value._seconds
+        elif isinstance(value, (datetime.timedelta, hightime.timedelta)):
+            return self._seconds < value.total_seconds()
+        else:
+            return NotImplemented  # type: ignore[unreachable]
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+        return f"{self.__class__.__name__}({self._seconds})"

--- a/tests/test_timedelta.py
+++ b/tests/test_timedelta.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 import hightime
+from tests.othertime import OtherTimeDelta
 from tests.shorthands import timedelta
 
 
@@ -325,6 +326,40 @@ def test_timedelta_comparison_unrelated_type(td: hightime.timedelta, other: Any)
         assert td >= other
     with pytest.raises(TypeError):
         assert other >= td
+
+
+@pytest.mark.parametrize(
+    "left, right, eq, lt",
+    [
+        (timedelta(s=1), OtherTimeDelta(1.0), True, False),
+        (timedelta(s=1), OtherTimeDelta(2.0), False, True),
+        (OtherTimeDelta(1.0), timedelta(s=1), True, False),
+        (OtherTimeDelta(1.0), timedelta(s=2), False, True),
+    ],
+)
+def test_timedelta_comparison_compatible_type(
+    left: hightime.timedelta | OtherTimeDelta,
+    right: hightime.timedelta | OtherTimeDelta,
+    eq: bool,
+    lt: bool,
+) -> None:
+    assert (left == right) == eq
+    assert (right == left) == eq
+
+    assert (left != right) == (not eq)
+    assert (right != left) == (not eq)
+
+    assert (left < right) == (lt and not eq)
+    assert (right > left) == (lt and not eq)
+
+    assert (left <= right) == (lt or eq)
+    assert (right >= left) == (lt or eq)
+
+    assert (left > right) == (not lt and not eq)
+    assert (right < left) == (not lt and not eq)
+
+    assert (left >= right) == (not lt or eq)
+    assert (right <= left) == (not lt or eq)
 
 
 def test_timedelta_bool() -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`datetime` and `timedelta`:
- Propagate `NotImplemented` correctly when calling ` self._cmp`. 

`datetime`:
- Swap if/else cases so the `date` code is in the `date` case, not in the `else` case.

`timedelta`:
- Use `timedelta._cmp` in `timedelta.__eq__`
- Return `NotImplemented` from `timedelta._cmp` instead of throwing `TypeError`

### Why should this Pull Request be merged?

Fixes #60 

Allows [nitypes.bintime.TimeDelta](https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/bintime/index.html#nitypes.bintime.TimeDelta) to support comparisons that `hightime.timedelta` does not.

### What testing has been done?

Ran `hightime` mypy and unit tests.
Ran `nitypes` unit tests and verified that the xfailed test cases are now xpassing.