### PR TITLE
hightime: Bump master branch version to 1.1.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "hightime"
 description = "Hightime Python API"
 license = "MIT"
 keywords = ["hightime"]
-version = "1.0.1.dev0"
+version = "1.1.0.dev0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump `master` branch version to 1.1.0.dev0.
The `releases/1.0` branch version is 1.0.1.dev0, in case we need to patch 1.0.

### Why should this Pull Request be merged?

Prepare for next release.

### What testing has been done?

N/A