### PR TITLE
fix: accept any tzinfo subclass in datetime fast-path

### DIFF
--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -105,8 +105,10 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
         """Construct a datetime."""
         if len(args) == 8 and "tzinfo" not in kwargs:
             # Allow the user to positionally specify timezone as the 8th param,
-            # to be compatible with datetime.datetime
-            if isinstance(args[-1], (std_datetime.timezone, type(None))):
+            # to be compatible with datetime.datetime. Accept any tzinfo
+            # subclass (e.g. zoneinfo.ZoneInfo, pytz timezones), not only
+            # datetime.timezone.
+            if isinstance(args[-1], (std_datetime.tzinfo, type(None))):
                 kwargs["tzinfo"] = args[-1]
                 args = args[:-1]
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -86,6 +86,17 @@ def test_datetime_tzinfo_as_femtoseconds() -> None:
     assert dt.tzinfo == std_datetime.timezone.utc
 
 
+def test_datetime_now_with_zoneinfo_tz() -> None:
+    # Regression for https://github.com/ni/hightime/issues/126: datetime.now
+    # forwards a ZoneInfo instance through __new__'s positional fast-path; the
+    # check must accept any tzinfo subclass, not only datetime.timezone.
+    from zoneinfo import ZoneInfo
+
+    tz = ZoneInfo("America/Chicago")
+    dt = hightime.datetime.now(tz=tz)
+    assert dt.tzinfo is tz
+
+
 def test_datetime_properties() -> None:
     dt = datetime(**{field: index + 1 for index, field in enumerate(_ALL_FIELDS)})
     for index, field in enumerate(_ALL_FIELDS):


### PR DESCRIPTION
Fixes #126.

`hightime.datetime.__new__` peels off a positional 8th argument and re-routes it to `tzinfo=` for compatibility with `datetime.datetime`'s constructor signature (which `now`/`fromtimestamp` etc. rely on). The isinstance check there only matched `datetime.timezone`, so calling `hightime.datetime.now(tz=ZoneInfo("America/Chicago"))` left the ZoneInfo in the positional slot and it ended up at the `femtosecond` check, producing `TypeError: an integer is required (got type ZoneInfo)`.

Widened the check to `datetime.tzinfo` so any conforming tzinfo (zoneinfo, pytz, custom) goes through the same fast-path.

Added a regression test that calls `hightime.datetime.now(tz=ZoneInfo(...))` and asserts the returned datetime carries the ZoneInfo through.