### PR TITLE
Fix ZoneInfo handling in datetime constructor

### DIFF
--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -106,7 +106,7 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
         if len(args) == 8 and "tzinfo" not in kwargs:
             # Allow the user to positionally specify timezone as the 8th param,
             # to be compatible with datetime.datetime
-            if isinstance(args[-1], (std_datetime.timezone, type(None))):
+            if isinstance(args[-1], (std_datetime.tzinfo, type(None))):
                 kwargs["tzinfo"] = args[-1]
                 args = args[:-1]
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -5,6 +5,7 @@ import datetime as std_datetime
 import pickle
 from decimal import Decimal
 from typing import Any, SupportsIndex, Type
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -537,6 +538,15 @@ def test_datetime_now_type() -> None:
     assert isinstance(hightime.datetime.now(), hightime.datetime)
 
 
+def test_datetime_now_with_zoneinfo() -> None:
+    tz = ZoneInfo("America/Chicago")
+
+    dt = hightime.datetime.now(tz=tz)
+
+    assert isinstance(dt, hightime.datetime)
+    assert dt.tzinfo is tz
+
+
 def test_datetime_fromtimestamp_type() -> None:
     assert isinstance(hightime.datetime.fromtimestamp(1587500974.003), hightime.datetime)
 
@@ -550,6 +560,15 @@ def test_datetime_astimezone_type() -> None:
     assert isinstance(
         datetime(tzinfo=tzinfo(hours=2)).astimezone(tzinfo(hours=1)), hightime.datetime
     )
+
+
+def test_datetime_astimezone_with_zoneinfo() -> None:
+    tz = ZoneInfo("America/Chicago")
+
+    dt = hightime.datetime(2026, 1, 1, tzinfo=std_datetime.timezone.utc).astimezone(tz)
+
+    assert isinstance(dt, hightime.datetime)
+    assert dt.tzinfo is tz
 
 
 def test_datetime_replace() -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #126.

This updates `hightime.datetime.__new__` to treat any `datetime.tzinfo` instance as the positional `tzinfo` argument that can be passed internally by `datetime.datetime`, instead of only accepting `datetime.timezone`. It also adds regression coverage for `ZoneInfo("America/Chicago")` through both `now(tz=...)` and `astimezone(...)`.

### Why should this Pull Request be merged?

`ZoneInfo` and other `tzinfo` subclasses are valid timezone values. Before this change, hightime interpreted them as its `femtosecond` argument and raised `TypeError`, which broke `now(tz=ZoneInfo(...))` and `astimezone(...)`.

### What testing has been done?

- `.venv/bin/python -m pytest tests/test_datetime.py::test_datetime_now_with_zoneinfo tests/test_datetime.py::test_datetime_astimezone_with_zoneinfo -q`
- `.venv/bin/python -m pytest tests/test_datetime.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/ni-python-styleguide lint`
- `.venv/bin/mypy`
- `.venv/bin/bandit -c pyproject.toml -r hightime`
- Manual `ZoneInfo("America/Chicago")` reproduction for `now(tz=...)` and `astimezone(...)`
