### PR TITLE
fix: correctly handle negative UTC offsets in isoformat

### DIFF
--- a/hightime/_datetime.py
+++ b/hightime/_datetime.py
@@ -1,4 +1,5 @@
 import datetime as std_datetime
+import re
 from collections import OrderedDict
 from itertools import dropwhile
 
@@ -198,10 +199,18 @@ class datetime(std_datetime.datetime):  # noqa: N801 - class name should use Cap
             value //= 1000
 
         fmt = specs[timespec]
-        iso_strs = super().isoformat(sep).split("+")
-        iso_strs[0] = iso_strs[0].split(".")[0]
-        iso_strs[0] += "." + fmt.format(self.microsecond, value)
-        return "+".join(iso_strs)
+        iso_str = super().isoformat(sep)
+        # Split off the UTC offset suffix (e.g. "+05:30", "-01:00", "+05:30:30").
+        # A simple split on "+" would silently drop negative-offset timezones.
+        tz_match = re.search(r"[+-]\d{2}:\d{2}(?::\d{2})?$", iso_str)
+        if tz_match:
+            tz_suffix = iso_str[tz_match.start() :]
+            iso_str = iso_str[: tz_match.start()]
+        else:
+            tz_suffix = ""
+        iso_str = iso_str.split(".")[0]
+        iso_str += "." + fmt.format(self.microsecond, value)
+        return iso_str + tz_suffix
 
     def replace(
         self,

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -167,11 +167,10 @@ def test_datetime_repr(dt: hightime.datetime, middle_part: str) -> None:
             "0001-01-01T00:00:00.000000000000000000000040",
             "+01:00",
         ),
-        pytest.param(
+        (
             datetime(1, 1, 1, ys=40, tzinfo=tzinfo(hours=-1)),
             "0001-01-01T00:00:00.000000000000000000000040",
             "-01:00",
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/52"),
         ),
         (
             datetime(1, 1, 1, ys=40, fold=1),


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/hightime/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #52.

`hightime.datetime.isoformat()` built its result by splitting the base `datetime.isoformat()` string on `"+"` to separate the UTC offset, then re-joining with `"+"`. Negative offsets use `"-"`, so the split found nothing and the high-precision fractional seconds were appended after the offset instead of after the seconds:

```python
>>> ht.datetime(2025, 1, 1, yoctosecond=40, tzinfo=dt.timezone(dt.timedelta(hours=-1))).isoformat()
'2025-01-01T00:00:00-01:00.000000000000000000000040'
```

This replaces the split with a regex match for the offset suffix (`[+-]HH:MM` or `[+-]HH:MM:SS`) at the end of the string, so the fractional part is inserted after the seconds and the offset is re-attached last. It also removes the `xfail` from the existing negative-offset case in `tests/test_datetime.py`, which now passes.

### Why should this Pull Request be merged?

The output was not a valid ISO 8601 string and could not be parsed back, for any sub-microsecond datetime west of UTC. Positive offsets and naive datetimes were unaffected, which is why it went unnoticed. The repository already had a test for the case, marked `xfail` against #52.

### What testing has been done?

- `python -m pytest tests/test_datetime.py -k isoformat` — 12 passed; the negative-offset case fails on `master` with the `xfail` removed, confirming the test covers the fix
- `python -m pytest tests/` — 408 passed
- `ni-python-styleguide lint` — clean
- `mypy` — Success: no issues found in 8 source files
- CI on this PR: 29/29 checks passing
